### PR TITLE
Add packaging and fix API docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM python:3.9.0-slim-buster
-RUN apt update && apt install git -y
-RUN pip3 install \
-        flask datajoint==0.13.dev2 pyjwt pyjwt[crypto]
-
-WORKDIR /src
+ARG PY_VER
+ARG DISTRO
+FROM datajoint/djbase:py${PY_VER}-${DISTRO}
+COPY --chown=dja:anaconda ./README.md ./requirements.txt ./setup.py \
+    /main/
+COPY --chown=dja:anaconda ./dj_gui_api_server /main/dj_gui_api_server
+RUN \
+    cd /main && \
+    pip install . && \
+    rm -R /main/*
+CMD ["djgui_api"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-DJ-GUI-API Backend
+# DJ-GUI-API Backend
 
 Built on top of flask
 
@@ -6,6 +6,6 @@ Requirements:
 - Docker
 - Docker Compose
 
-To start the server simply run: ```docker-compose up```
+To start the server simply run: `docker-compose up`
 
 NOTE: The docker-compose file creates a docker network call dj-gui-api which is meant to connect to front end to this back end via reverse proxy for developemnt. Final deployment will be using K8 or electron with some production server for flask

--- a/dj_gui_api_server/__init__.py
+++ b/dj_gui_api_server/__init__.py
@@ -1,0 +1,1 @@
+from .version import __version__

--- a/dj_gui_api_server/version.py
+++ b/dj_gui_api_server/version.py
@@ -1,0 +1,2 @@
+"""DJGUI API metadata."""
+__version__ = '0.0.0'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,19 +1,26 @@
+# PROD: docker-compose up --build -d
+# DEV: docker-compose up
 version: "2.4"
 services:
   dj-gui-api:
-    build: .
-    ports:
-      - "5000:5000"
-    volumes:
-      - ./:/src
+    build:
+      context: .
+      args:
+        - PY_VER=3.8
+        - DISTRO=alpine
+    image: dj-gui-api
     environment:
       - PRIVATE_KEY
       - PUBLIC_KEY
       - FLASK_ENV=development # enables logging to console from Flask
     networks:
       - dj-gui-api
-    working_dir: /src/
-    command: "python3 ./dj_gui_api_server/DJGUIAPIServer.py"
+    # volumes:
+    #   - ./dj_gui_api_server:/opt/conda/lib/python3.8/site-packages/dj_gui_api_server
+    ports:
+      - "5000:5000"
+    working_dir: /main
+    command: djgui_api
 
 networks:
   dj-gui-api:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+datajoint==0.13.dev2
+pyjwt[crypto]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+from setuptools import setup, find_packages
+from os import path, listdir
+import re
+
+pkg_name = 'dj_gui_api_server'
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'README.md'), 'r') as f:
+    long_description = f.read()
+
+with open(path.join(here, pkg_name, 'version.py')) as f:
+    exec(f.read())
+
+with open(path.join(here, 'requirements.txt')) as f:
+    requirements = ['{pkg} @ {target}#egg={pkg}'.format(
+        pkg=re.search(r'/([A-Za-z0-9\-]+)\.git', r).group(1),
+        target=r) if '+' in r else r for r in f.read().splitlines() if '#' not in r]
+
+setup(
+    name=pkg_name,
+    version=__version__,
+    author='DataJoint Neuro',
+    author_email='info@vathes.com',
+    description='A generic REST API for DataJoint pipelines.',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://datajoint.io',
+    packages=find_packages(exclude=['test*', 'docs']),
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
+    ],
+    install_requires=requirements,
+    entry_points={
+        'console_scripts': ['djgui_api={}.DJGUIAPIServer:run'.format(pkg_name)],
+    },
+)


### PR DESCRIPTION
So this is how you achieve proper packaging and API docs in Python. There is still plenty to clean up but this gives the general idea to prepare docs so that they are `help` and Sphinx-compatible. Also, packaging will be utilized both for deployments and to perform unit tests.

Fix #41 
Fix #42