### PR TITLE
Fix Publish: Adjust version reference in GH Actions

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -113,16 +113,16 @@ jobs:
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2
         with:
-          validation_depth: 10
-          version: ${{steps.tag_name.outputs.current_version}}
           path: ./CHANGELOG.md
+          validation_depth: 10
+          version: ${{env.PHARUS_VERSION}}
       - name: Create GH release
         id: create_gh_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          tag_name: ${{github.ref}}
+          tag_name: ${{steps.changelog_reader.outputs.version}}
           release_name: Release ${{steps.changelog_reader.outputs.version}}
           body: ${{steps.changelog_reader.outputs.changes}}
           prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.1.0a1] - 2021-02-17
+## [0.1.0a2] - 2021-02-18
 ### Added
 - List schemas method.
 - List tables method.

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -10,6 +10,27 @@ services:
     image: datajoint/mysql:5.7
     environment:
       - MYSQL_ROOT_PASSWORD=simple
+  # changelog-linter:
+  #   image: node:10-alpine
+  #   volumes:
+  #     - ./CHANGELOG.md:/main/CHANGELOG.md:ro
+  #   working_dir: /main
+  #   command:
+  #     - sh
+  #     - -c
+  #     - |
+  #       npm i -g @brightcove/kacl
+  #       cat > package.json <<-EOF
+  #       {
+  #         "name": "example",
+  #         "version": "0.0.0",
+  #         "repository": {
+  #           "type": "git",
+  #           "url": "https://github.com/org/repo"
+  #         }
+  #       }
+  #       EOF
+  #       kacl lint && tail -f /dev/null
   pharus:
     <<: *net
     extends:
@@ -43,6 +64,8 @@ services:
           tail -f /dev/null
         fi
     depends_on:
+      # changelog-linter:
+      #   condition: service_started
       db:
         condition: service_healthy
 networks:

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = '0.1.0a1'
+__version__ = '0.1.0a2'


### PR DESCRIPTION
This should fix changelog parsing issues. There are a few comments here as well but added intentionally in case I need it should the fix fail. Once we are at a stable point I'll either add it as a proper check or remove them.