### PR TITLE
Add dev environment and update docs

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get changelog entry
         id: changelog_reader
-        uses: guzman-raphael/changelog-reader-action@v5
+        uses: guzman-raphael/changelog-reader-action@v6
         with:
           path: ./CHANGELOG.md
       - name: Verify changelog parsing
@@ -118,7 +118,7 @@ jobs:
           echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
       - name: Get changelog entry
         id: changelog_reader
-        uses: guzman-raphael/changelog-reader-action@v5
+        uses: guzman-raphael/changelog-reader-action@v6
         with:
           path: ./CHANGELOG.md
           version: ${{env.PHARUS_VERSION}}

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get changelog entry
         id: changelog_reader
-        uses: guzman-raphael/changelog-reader-action@v6
+        uses: guzman-raphael/changelog-reader-action@v7
         with:
           path: ./CHANGELOG.md
       - name: Verify changelog parsing
@@ -118,7 +118,7 @@ jobs:
           echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
       - name: Get changelog entry
         id: changelog_reader
-        uses: guzman-raphael/changelog-reader-action@v6
+        uses: guzman-raphael/changelog-reader-action@v7
         with:
           path: ./CHANGELOG.md
           version: ${{env.PHARUS_VERSION}}

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get changelog entry
         id: changelog_reader
-        uses: guzman-raphael/changelog-reader-action@v7
+        uses: guzman-raphael/changelog-reader-action@v5
         with:
           path: ./CHANGELOG.md
       - name: Verify changelog parsing
@@ -117,7 +117,7 @@ jobs:
           echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
       - name: Get changelog entry
         id: changelog_reader
-        uses: guzman-raphael/changelog-reader-action@v7
+        uses: guzman-raphael/changelog-reader-action@v5
         with:
           path: ./CHANGELOG.md
           version: ${{env.PHARUS_VERSION}}

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -42,7 +42,6 @@ jobs:
       IMAGE: ${{matrix.image}}
       DOCKER_CLIENT_TIMEOUT: "120"
       COMPOSE_HTTP_TIMEOUT: "120"
-      AS_SCRIPT: "TRUE"
     steps:
       - uses: actions/checkout@v2
       - name: Compile image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 ## [Unreleased]
 ### Added
-- Add docker `dev` environment that supports hot reloading.
+- Docker `dev` environment that supports hot reloading.
+- Documentation on setting up environments within `docker-compose` header.
 
 ## [0.1.0a5] - 2021-02-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.1.0a6] - 2021-02-19
+## [Unreleased]
 ### Added
 - Add docker `dev` environment that supports hot reloading.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Docker `dev` environment that supports hot reloading.
 - Documentation on setting up environments within `docker-compose` header.
 
+### Removed
+- Docker `base` environment to simplify dependencies.
+
 ## [0.1.0a5] - 2021-02-18
 ### Added
 - List schemas method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.0a6] - 2021-02-19
+### Added
+- Add docker `dev` environment that supports hot reloading.
+
 ## [0.1.0a5] - 2021-02-18
 ### Added
 - List schemas method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Read table definition method.
 - Support for DataJoint attribute types: `varchar`, `int`, `float`, `datetime`, `date`, `time`, `decimal`, `uuid`.
 - Check dependency utility to determine child table references.
+
+[Unreleased]: https://github.com/datajoint/pharus/compare/0.1.0a5...HEAD
+[0.1.0a5]: https://github.com/datajoint/pharus/releases/tag/0.1.0a5

--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ Usage and API documentation currently available within method docstrings. See Py
 
 ## Run Locally w/ Docker
 
-- Copy a `*-docker-compose.yaml` file corresponding to your usage to `docker-compose.yaml`. This file is untracked so feel free to modify as necessary.
-- Check the first comment which will provide best instruction on how to start the service.
+- Copy a `*-docker-compose.yaml` file corresponding to your usage to `docker-compose.yaml`. This file is untracked so feel free to modify as necessary. Idea is to commit anything generic but system/setup dependent should go on 'your' version i.e. local UID/GID, etc.
+- Check the first comment which will provide the best instruction on how to start the service; yes, it is a bit long. Note: Any of the keyword arguments prepended to the `docker-compose` command can be safely moved into a dedicated `.env` and read automatically if they are not evaluated i.e. `$(...)`. Below is a brief description of the non-evaluated environment variables:
+
+```shell
+PY_VER=3.8    # Python version: 3.6|3.7|3.8
+IMAGE=djtest  # Image type:     djbase|djtest|djlab|djlabhub
+DISTRO=alpine # Distribution:   alpine|debian
+AS_SCRIPT=    # If 'TRUE', will not keep container alive but run tests and exit
+```
 
 > ⚠️ Deployment options currently being considered are [Docker Compose](https://docs.docker.com/compose/install/) and [Kubernetes](https://kubernetes.io/docs/tutorials/kubernetes-basics/).
 
@@ -30,17 +37,6 @@ Usage and API documentation currently available within method docstrings. See Py
 - Set environment variables for port assignment (`PHARUS_PORT`, defaults to 5000) and API route prefix (`PHARUS_PREFIX` e.g. `/api`, defaults to empty string).
 - For development, use CLI command `pharus`. This method supports hot-reloading so probably best coupled with `pip install -e ...`.
 - For production, use `gunicorn --bind 0.0.0.0:${PHARUS_PORT} pharus.server:app`.
-
-## Run Tests for Development w/ Docker
-
-- Create a `.env` as appropriate for your setup:
-  ```shell
-  PY_VER=3.8    # Python version: 3.6|3.7|3.8
-  IMAGE=djtest  # Image type:     djbase|djtest|djlab|djlabhub
-  DISTRO=alpine # Distribution:   alpine|debian
-  AS_SCRIPT=    # If 'TRUE', will not keep container alive but run tests and exit
-  ```
-- Navigate to `test-docker-compose.yaml` and check first comment which will provide best instruction on how to start the service. Yes, the command is a bit long...
 
 ## Run Tests for Development w/ Pytest and Flake8
 

--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -1,9 +1,0 @@
-# WARNING: Do not run this compose file directly. Please see other compose files.
-version: "2.4"
-services:
-  pharus:
-    image: datajoint/pharus:${PHARUS_VERSION}
-    environment:
-      - PHARUS_PRIVATE_KEY
-      - PHARUS_PUBLIC_KEY
-    user: ${HOST_UID}:anaconda

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -1,16 +1,21 @@
 # PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-build.yaml up --exit-code-from pharus --build
+#
+# Intended for updating dependencies and docker image.
+# Used to build release artifacts.
 version: "2.4"
 services:
   pharus:
-    extends:
-      file: ./docker-compose-base.yaml
-      service: pharus
     build:
       context: .
       args:
         - PY_VER
         - DISTRO
         - IMAGE
+    image: datajoint/pharus:${PHARUS_VERSION}
+    environment:
+      - PHARUS_PRIVATE_KEY
+      - PHARUS_PUBLIC_KEY
+    user: ${HOST_UID}:anaconda
     volumes:
       - .:/main
     command:

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -1,4 +1,4 @@
-# PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-build.yaml up --exit-code-from pharus --build
+# PY_VER=3.8 IMAGE=djbase DISTRO=alpine PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-build.yaml up --exit-code-from pharus --build
 #
 # Intended for updating dependencies and docker image.
 # Used to build release artifacts.

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -1,14 +1,36 @@
-# docker-compose -f docker-compose-deploy.yaml pull
-# docker-compose -f docker-compose-deploy.yaml up -d
+# PHARUS_VERSION=0.1.0a5 docker-compose -f docker-compose-deploy.yaml pull
+# PHARUS_VERSION=0.1.0a5 docker-compose -f docker-compose-deploy.yaml up -d
 #
 # Intended for production deployment.
-# Note: You must run both commands above
+# Note: You must run both commands above for minimal outage
+# Make sure to add an entry into your /etc/hosts file as `127.0.0.1 fakeservices.datajoint.io`
+# This serves to as an alias for the domain to resolve locally.
+# With this config and the configuration below in NGINX, you should be able to verify it is
+# running properly with a `curl https://fakeservices.datajoint.io/api/version`
 version: "2.4"
+x-net: &net
+  networks:
+      - main
 services:
   pharus:
-    image: datajoint/pharus:latest
+    <<: *net
+    image: datajoint/pharus:${PHARUS_VERSION}
     # environment: # configurable values with defaults
     #   - PHARUS_PORT=5000
     #   - PHARUS_PREFIX=/
+  fakeservices.datajoint.io:
+    <<: *net
+    image: raphaelguzman/nginx:v0.0.15
+    environment:
+      - ADD_pharus_TYPE=REST
+      - ADD_pharus_ENDPOINT=pharus:5000
+      - ADD_pharus_PREFIX=/api
+      - HTTPS_PASSTHRU=TRUE
     ports:
-      - "5000:5000"
+      - "443:443"
+      - "80:80"
+    depends_on:
+      pharus:
+        condition: service_healthy
+networks:
+  main:

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -1,14 +1,14 @@
-# PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') docker-compose -f docker-compose-deploy.yaml pull
-# PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') docker-compose -f docker-compose-deploy.yaml up -d
+# docker-compose -f docker-compose-deploy.yaml pull
+# docker-compose -f docker-compose-deploy.yaml up -d
+#
+# Intended for production deployment.
 # Note: You must run both commands above
 version: "2.4"
 services:
   pharus:
-    extends:
-      file: ./docker-compose-base.yaml
-      service: pharus
-    environment:
-      - PHARUS_PORT=5000
-      - PHARUS_PREFIX=/now
+    image: datajoint/pharus:latest
+    # environment: # configurable values with defaults
+    #   - PHARUS_PORT=5000
+    #   - PHARUS_PREFIX=/
     ports:
       - "5000:5000"

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -4,9 +4,9 @@
 # Intended for production deployment.
 # Note: You must run both commands above for minimal outage
 # Make sure to add an entry into your /etc/hosts file as `127.0.0.1 fakeservices.datajoint.io`
-# This serves to as an alias for the domain to resolve locally.
+# This serves as an alias for the domain to resolve locally.
 # With this config and the configuration below in NGINX, you should be able to verify it is
-# running properly with a `curl https://fakeservices.datajoint.io/api/version`
+# running properly with a `curl https://fakeservices.datajoint.io/api/version`.
 version: "2.4"
 x-net: &net
   networks:

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,0 +1,16 @@
+# PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-dev.yaml up
+#
+# Intended for normal development. Supports hot/live reloading.
+# Note: If requirements or Dockerfile change, will need to add --build flag
+version: "2.4"
+services:
+  pharus:
+    <<: *net
+    extends:
+      file: ./docker-compose-build.yaml
+      service: pharus
+    environment:
+      - FLASK_ENV=development # enables logging to console from Flask
+    volumes:
+      - ./pharus:/opt/conda/lib/python3.8/site-packages/pharus
+    command: pharus

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,11 +1,11 @@
 # PY_VER=3.8 IMAGE=djbase DISTRO=alpine PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-dev.yaml up
 #
 # Intended for normal development. Supports hot/live reloading.
-# Note: If requirements or Dockerfile change, will need to add --build flag to docker-compose
+# Note: If requirements or Dockerfile change, will need to add --build flag to docker-compose.
 # Make sure to add an entry into your /etc/hosts file as `127.0.0.1 fakeservices.datajoint.io`
-# This serves to as an alias for the domain to resolve locally.
+# This serves as an alias for the domain to resolve locally.
 # With this config and the configuration below in NGINX, you should be able to verify it is
-# running properly with a `curl https://fakeservices.datajoint.io/api/version`
+# running properly with a `curl https://fakeservices.datajoint.io/api/version`.
 version: "2.4"
 x-net: &net
   networks:

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,8 +1,15 @@
-# PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-dev.yaml up
+# PY_VER=3.8 IMAGE=djbase DISTRO=alpine PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-dev.yaml up
 #
 # Intended for normal development. Supports hot/live reloading.
-# Note: If requirements or Dockerfile change, will need to add --build flag
+# Note: If requirements or Dockerfile change, will need to add --build flag to docker-compose
+# Make sure to add an entry into your /etc/hosts file as `127.0.0.1 fakeservices.datajoint.io`
+# This serves to as an alias for the domain to resolve locally.
+# With this config and the configuration below in NGINX, you should be able to verify it is
+# running properly with a `curl https://fakeservices.datajoint.io/api/version`
 version: "2.4"
+x-net: &net
+  networks:
+      - main
 services:
   pharus:
     <<: *net
@@ -14,3 +21,19 @@ services:
     volumes:
       - ./pharus:/opt/conda/lib/python3.8/site-packages/pharus
     command: pharus
+  fakeservices.datajoint.io:
+    <<: *net
+    image: raphaelguzman/nginx:v0.0.15
+    environment:
+      - ADD_pharus_TYPE=REST
+      - ADD_pharus_ENDPOINT=pharus:5000
+      - ADD_pharus_PREFIX=/api
+      - HTTPS_PASSTHRU=TRUE
+    ports:
+      - "443:443"
+      - "80:80"
+    depends_on:
+      pharus:
+        condition: service_healthy
+networks:
+  main:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,7 +1,7 @@
 # PY_VER=3.8 IMAGE=djtest DISTRO=alpine AS_SCRIPT=FALSE PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
 #
 # Intended for running test suite locally.
-# Note: If requirements or Dockerfile change, will need to add --build flag
+# Note: If requirements or Dockerfile change, will need to add --build flag.
 version: "2.4"
 x-net: &net
   networks:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,4 +1,6 @@
 # PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
+#
+# Intended for running test suite locally.
 # Note: If requirements or Dockerfile change, will need to add --build flag
 version: "2.4"
 x-net: &net

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,4 +1,4 @@
-# PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
+# PY_VER=3.8 IMAGE=djtest DISTRO=alpine AS_SCRIPT=FALSE PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}') HOST_UID=$(id -u) docker-compose -f docker-compose-test.yaml up --exit-code-from pharus
 #
 # Intended for running test suite locally.
 # Note: If requirements or Dockerfile change, will need to add --build flag
@@ -30,8 +30,8 @@ services:
       - sh
       - -c
       - |
-        if [ ! -z "$${AS_SCRIPT}" ]; then
-          set -e
+        set -e
+        if echo "${AS_SCRIPT}" | grep -i true &>/dev/null; then
           echo "------ SYNTAX TESTS ------"
           PKG_DIR=/opt/conda/lib/python3.8/site-packages/pharus
           flake8 $${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -41,7 +41,7 @@ services:
           flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=95 --statistics
         else
           echo "=== Running ==="
-          echo "Please see 'LNX-docker-compose.yaml' for detail on running tests."
+          echo "Please see 'docker-compose-test.yaml' for detail on running tests."
           tail -f /dev/null
         fi
     depends_on:

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = '0.1.0a5'
+__version__ = '0.1.0a6'

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = '0.1.0a6'
+__version__ = '0.1.0a5'


### PR DESCRIPTION
This PR serves to:
- Add `dev` docker environment that supports hot/live reloading.
- Remove `base` docker environment to simplify dependencies.
- Add documentation on running environments.
- Update general docs.

Fix #74