### PR TITLE
Allow cascade option for delete and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 ## [Unreleased]
 
+## Security
+- Documentation with detail regarding warning on bearer token. (#83) PR #88
+
 ## Fixed
 - Incorrect virtual module reference of `schema_virtual_module` in table metadata. (#85) PR #88
 
@@ -12,7 +15,6 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Documentation on setting up environments within `docker-compose` header. PR #79
 - `cascade` option for `/delete_tuple` route. (#86) PR #88
 - When delete with `cascade=False` fails due to foreign key relations, returns a HTTP error code of `409 Conflict` with a JSON body containing specifics of 1st child. (#86) PR #88
-- Documentation with detail regarding warning on bearer token. (#83) PR #88
 
 ### Changed
 - Replaced `DJConnector.snake_to_camel_case` usage with `datajoint.utils.to_camel_case`. PR #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,24 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
 ## [Unreleased]
+
+## Fixed
+- Incorrect virtual module reference of `schema_virtual_module` in table metadata. (#85) PR #88
+
 ### Added
-- Docker `dev` environment that supports hot reloading.
-- Documentation on setting up environments within `docker-compose` header.
+- Docker `dev` environment that supports hot reloading. PR #79
+- Documentation on setting up environments within `docker-compose` header. PR #79
+- `cascade` option for `/delete_tuple` route. (#86) PR #88
+- When delete with `cascade=False` fails due to foreign key relations, returns a HTTP error code of `409 Conflict` with a JSON body containing specfics on 1st child. (#86) PR #88
+- Documentation with detail regarding bearer token possible vulnerability (which database credentials) if hosted remotely. Recommend local deployment only for now. (#83) PR #88
+
+### Changed
+- Replaced `DJConnector.snake_to_camel_case` usage with `datajoint.utils.to_camel_case`. PR #88
+- Default behavior for `/delete_tuple` now deletes without cascading. (#86) PR #88
+- Consolidated `pytest` fixtures into `__init__.py` to facilate reuse. PR #88
 
 ### Removed
-- Docker `base` environment to simplify dependencies.
+- Docker `base` environment to simplify dependencies. PR #79
 
 ## [0.1.0a5] - 2021-02-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 ### Added
 - List schemas method.
 - List tables method.
-- Create, Read, Update, Delete (CRUD) operations for DataJoint table tiers: `dj.Manual`, `dj.Lookup`.
+- Data entry, update, delete, and view operations for DataJoint table tiers: `dj.Manual`, `dj.Lookup`.
 - Read table records with proper paging and compounding restrictions (i.e. filters).
 - Read table definition method.
 - Support for DataJoint attribute types: `varchar`, `int`, `float`, `datetime`, `date`, `time`, `decimal`, `uuid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Docker `dev` environment that supports hot reloading. PR #79
 - Documentation on setting up environments within `docker-compose` header. PR #79
 - `cascade` option for `/delete_tuple` route. (#86) PR #88
-- When delete with `cascade=False` fails due to foreign key relations, returns a HTTP error code of `409 Conflict` with a JSON body containing specfics on 1st child. (#86) PR #88
-- Documentation with detail regarding bearer token possible vulnerability (which database credentials) if hosted remotely. Recommend local deployment only for now. (#83) PR #88
+- When delete with `cascade=False` fails due to foreign key relations, returns a HTTP error code of `409 Conflict` with a JSON body containing specfics of 1st child. (#86) PR #88
+- Documentation with detail regarding bearer token possible vulnerability (which contains database credentials) if hosted remotely. Recommend local deployment only for now. (#83) PR #88
 
 ### Changed
 - Replaced `DJConnector.snake_to_camel_case` usage with `datajoint.utils.to_camel_case`. PR #88
 - Default behavior for `/delete_tuple` now deletes without cascading. (#86) PR #88
-- Consolidated `pytest` fixtures into `__init__.py` to facilate reuse. PR #88
+- Consolidated `pytest` fixtures into `__init__.py` to facilitate reuse. PR #88
 
 ### Removed
 - Docker `base` environment to simplify dependencies. PR #79

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Docker `dev` environment that supports hot reloading. PR #79
 - Documentation on setting up environments within `docker-compose` header. PR #79
 - `cascade` option for `/delete_tuple` route. (#86) PR #88
-- When delete with `cascade=False` fails due to foreign key relations, returns a HTTP error code of `409 Conflict` with a JSON body containing specfics of 1st child. (#86) PR #88
-- Documentation with detail regarding bearer token possible vulnerability (which contains database credentials) if hosted remotely. Recommend local deployment only for now. (#83) PR #88
+- When delete with `cascade=False` fails due to foreign key relations, returns a HTTP error code of `409 Conflict` with a JSON body containing specifics of 1st child. (#86) PR #88
+- Documentation with detail regarding warning on bearer token. (#83) PR #88
 
 ### Changed
 - Replaced `DJConnector.snake_to_camel_case` usage with `datajoint.utils.to_camel_case`. PR #88

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ AS_SCRIPT=    # If 'TRUE', will not keep container alive but run tests and exit
   ```shell
   PKG_DIR=/opt/conda/lib/python3.8/site-packages/pharus # path to pharus installation
   TEST_DB_SERVER=example.com:3306 # testing db server address
-  TEST_DB_USER=root # testing db server user (needs CRUD on schemas, tables, users)
+  TEST_DB_USER=root # testing db server user (needs DDL privilege)
   TEST_DB_PASS=unsecure # testing db server password
   ```
 - For syntax tests, run `flake8 ${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics`

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -36,7 +36,7 @@ services:
           PKG_DIR=/opt/conda/lib/python3.8/site-packages/pharus
           flake8 $${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics
           echo "------ UNIT TESTS ------"
-          pytest -sv --cov-report term-missing --cov=$${PKG_DIR} /main/tests
+          pytest -sv --cov-report term-missing --cov=pharus /main/tests
           echo "------ STYLE TESTS ------"
           flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=95 --statistics
         else

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -68,12 +68,22 @@ def api_version():
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/login", methods=['POST'])
 def login():
     """
-    *WARNING*: Currently, this implementation exposes user database credentials in the bearer
-        token. This means it is not recommended for production use and should be avoided
-        unless clients are co-located with Pharus server. Secure certificates are highly
-        recommended (i.e. TLS/SSL) along with not exposing publicly the ports pointed to the
-        Pharus server. This issue is currently being tracked in
-        https://github.com/datajoint/pharus/issues/82.
+    *WARNING*: Currently, this implementation exposes user database credentials as plain text
+        in POST body once and stores it within a bearer token as Base64 encoded for subsequent
+        requests. That is how the server is able to submit queries on user's behalf. Due to
+        this, it is required that remote hosts expose the server only under HTTPS to ensure
+        end-to-end encryption. Sending passwords in plain text over HTTPS in POST request body
+        is common and utilized by companies such as GitHub (2021) and Chase Bank (2021). On
+        server side, there is no caching, logging, or storage of received passwords or tokens
+        and thus available only briefly in memory. This means the primary vulnerable point is
+        client side. Users should be responsible with their passwords and bearer tokens
+        treating them as one-in-the-same. Be aware that if your client system happens to be
+        compromised, a bad actor could monitor your outgoing network requests and capture/log
+        your credentials. However, in such a terrible scenario, a bad actor would not only
+        collect credentials for your DataJoint database but also other sites such as
+        github.com, chase.com, etc. Please be responsible and vigilant with credentials and
+        tokens on client side systems. Improvements to the above strategy is currently being
+        tracked in https://github.com/datajoint/pharus/issues/82.
     Login route which uses DataJoint database server login. Expects:
         (html:POST:body): json with keys
             {databaseAddress: string, username: string, password: string}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,330 @@
+import pytest
+from pharus.server import app
+from os import getenv
+import datajoint as dj
+from datetime import date
+from random import randint, choice, seed, getrandbits
+from faker import Faker
+seed('lock')  # Pin down randomizer between runs
+faker = Faker()
+Faker.seed(0)  # Pin down randomizer between runs
+SCHEMA_PREFIX = 'test_'
+
+
+@pytest.fixture
+def client():
+    """REST client interface."""
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def token(client):
+    """Root Bearer token."""
+    yield client.post('/login', json=dict(databaseAddress=getenv('TEST_DB_SERVER'),
+                                          username=getenv('TEST_DB_USER'),
+                                          password=getenv('TEST_DB_PASS'))).json['jwt']
+
+
+@pytest.fixture
+def group1_token(client, connection):
+    connection.query("""
+                     CREATE USER IF NOT EXISTS 'group1'@'%%'
+                     IDENTIFIED BY 'group1';
+                     """)
+    connection.query(
+        f"GRANT ALL PRIVILEGES ON `{SCHEMA_PREFIX}group1_%%`.* TO 'group1'@'%%';")
+    yield client.post('/login', json=dict(databaseAddress=getenv('TEST_DB_SERVER'),
+                                          username='group1',
+                                          password='group1')).json['jwt']
+    connection.query("DROP USER 'group1'@'%%';")
+
+
+@pytest.fixture
+def connection():
+    """Root database connection."""
+    dj.config['safemode'] = False
+    connection = dj.conn(host=getenv('TEST_DB_SERVER'),
+                         user=getenv('TEST_DB_USER'),
+                         password=getenv('TEST_DB_PASS'), reset=True)
+    yield connection
+    dj.config['safemode'] = True
+    connection.close()
+
+
+@pytest.fixture
+def schema_main(connection):
+    """Main test schema."""
+    main = dj.Schema(f'{SCHEMA_PREFIX}main', connection=connection)
+    yield main
+    main.drop()
+
+
+@pytest.fixture
+def schemas_simple(connection):
+    """Simple test schemas."""
+
+    group1_simple = dj.Schema(f'{SCHEMA_PREFIX}group1_simple', connection=connection)
+    group2_simple = dj.Schema(f'{SCHEMA_PREFIX}group2_simple', connection=connection)
+
+    @group1_simple
+    class TableA(dj.Lookup):
+        definition = """
+        a_id: int
+        ---
+        a_name: varchar(30)
+        """
+        contents = [(0, 'Raphael',), (1, 'Bernie',)]
+
+    @group1_simple
+    class TableB(dj.Lookup):
+        definition = """
+        -> TableA
+        b_id: int
+        ---
+        b_number: float
+        """
+        contents = [(0, 10, 22.12), (0, 11, -1.21,), (1, 21, 7.77,)]
+
+    @group2_simple
+    class DiffTableB(dj.Lookup):
+        definition = """
+        -> TableA
+        bs_id: int
+        ---
+        bs_number: float
+        """
+        contents = [(0, -10, -99.99), (0, -11, 287.11,)]
+
+    @group1_simple
+    class TableC(dj.Lookup):
+        definition = """
+        -> TableB
+        c_id: int
+        ---
+        c_int: int
+        """
+        contents = [(0, 10, 100, -8), (0, 11, 200, -9,), (0, 11, 300, -7,)]
+
+    yield group1_simple, group2_simple
+
+    group2_simple.drop()
+    group1_simple.drop()
+
+
+@pytest.fixture
+def Student(schema_main):
+    """Student table for testing."""
+    @schema_main
+    class Student(dj.Lookup):
+        definition = """
+        student_id: int
+        ---
+        student_name: varchar(50)
+        student_ssn: varchar(20)
+        student_enroll_date: datetime
+        student_balance: float
+        student_parking_lot=null : varchar(20)
+        student_out_of_state: bool
+        """
+        contents = [(i, faker.name(), faker.ssn(), faker.date_between_dates(
+                        date_start=date(2021, 1, 1), date_end=date(2021, 1, 31)),
+                     round(randint(1000, 3000), 2),
+                     choice([None, 'LotA', 'LotB', 'LotC']),
+                     bool(getrandbits(1))) for i in range(100)]
+    yield Student
+    Student.drop()
+
+
+@pytest.fixture
+def Int(schema_main):
+    """Integer basic table for testing."""
+    @schema_main
+    class Int(dj.Manual):
+        definition = """
+        id: int
+        ---
+        int_attribute: int
+        """
+    yield Int
+    Int.drop()
+
+
+@pytest.fixture
+def Float(schema_main):
+    """Float basic table for testing."""
+    @schema_main
+    class Float(dj.Manual):
+        definition = """
+        id: int
+        ---
+        float_attribute: float
+        """
+    yield Float
+    Float.drop()
+
+
+@pytest.fixture
+def Decimal(schema_main):
+    """Decimal basic table for testing."""
+    @schema_main
+    class Decimal(dj.Manual):
+        definition = """
+        id: int
+        ---
+        decimal_attribute: decimal(5, 2)
+        """
+    yield Decimal
+    Decimal.drop()
+
+
+@pytest.fixture
+def String(schema_main):
+    @schema_main
+    class String(dj.Manual):
+        definition = """
+        id: int
+        ---
+        string_attribute: varchar(32)
+        """
+    yield String
+    String.drop()
+
+
+@pytest.fixture
+def Bool(schema_main):
+    @schema_main
+    class Bool(dj.Manual):
+        definition = """
+        id: int
+        ---
+        bool_attribute: bool
+        """
+    yield Bool
+    Bool.drop()
+
+
+@pytest.fixture
+def Date(schema_main):
+    @schema_main
+    class Date(dj.Manual):
+        definition = """
+        id: int
+        ---
+        date_attribute: date
+        """
+    yield Date
+    Date.drop()
+
+
+@pytest.fixture
+def Datetime(schema_main):
+    @schema_main
+    class Datetime(dj.Manual):
+        definition = """
+        id: int
+        ---
+        datetime_attribute: datetime
+        """
+    yield Datetime
+    Datetime.drop()
+
+
+@pytest.fixture
+def Timestamp(schema_main):
+    @schema_main
+    class Timestamp(dj.Manual):
+        definition = """
+        id: int
+        ---
+        timestamp_attribute: timestamp
+        """
+    yield Timestamp
+    Timestamp.drop()
+
+
+@pytest.fixture
+def Time(schema_main):
+    @schema_main
+    class Time(dj.Manual):
+        definition = """
+        id: int
+        ---
+        time_attribute: time
+        """
+    yield Time
+    Time.drop()
+
+
+@pytest.fixture
+def Blob(schema_main):
+    @schema_main
+    class Blob(dj.Manual):
+        definition = """
+        id: int
+        ---
+        blob_attribute: blob
+        """
+    yield Blob
+    Blob.drop()
+
+
+@pytest.fixture
+def Longblob(schema_main):
+    @schema_main
+    class Longblob(dj.Manual):
+        definition = """
+        id: int
+        ---
+        longblob_attribute: longblob
+        """
+    yield Longblob
+    Longblob.drop()
+
+
+@pytest.fixture
+def Uuid(schema_main):
+    @schema_main
+    class Uuid(dj.Manual):
+        definition = """
+        id: int
+        ---
+        uuid_attribute: uuid
+        """
+    yield Uuid
+    Uuid.drop()
+
+
+@pytest.fixture
+def ParentPart(schema_main):
+    @schema_main
+    class ScanData(dj.Manual):
+        definition = """
+        scan_id : int unsigned
+        ---
+        data: int unsigned
+        """
+
+    @schema_main
+    class ProcessScanData(dj.Computed):
+        definition = """
+        -> ScanData # Forigen Key Reference
+        ---
+        processed_scan_data : int unsigned
+        """
+
+        class ProcessScanDataPart(dj.Part):
+            definition = """
+            -> ProcessScanData
+            ---
+            processed_scan_data_part : int unsigned
+            """
+
+        def make(self, key):
+            scan_data_dict = (ScanData & key).fetch1()
+            self.insert1(dict(key, processed_scan_data=scan_data_dict['data']))
+            self.ProcessScanDataPart.insert1(
+                dict(key, processed_scan_data_part=scan_data_dict['data'] * 2))
+
+    yield ScanData, ProcessScanData
+    ScanData.drop()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,68 @@
+from . import SCHEMA_PREFIX, token, client, connection, schemas_simple
+import datajoint as dj
+
+
+def test_delete_dependent_with_cascade(token, client, connection, schemas_simple):
+    schema_name = f'{SCHEMA_PREFIX}group1_simple'
+    table_name = 'TableB'
+    restriction = dict(a_id=0, b_id=11)
+    vm = dj.VirtualModule('group1_simple', schema_name)
+    print(getattr(vm, table_name) & restriction)
+    REST_response = client.post(
+        '/delete_tuple?cascade=tRuE',
+        headers=dict(Authorization=f'Bearer {token}'),
+        json=dict(schemaName=schema_name,
+                  tableName=table_name,
+                  restrictionTuple=restriction))
+    assert REST_response.status_code == 200
+    assert len(getattr(vm, table_name) & restriction) == 0
+    assert len(getattr(vm, 'TableC') & restriction) == 0
+
+
+def test_delete_dependent_without_cascade(token, client, connection, schemas_simple):
+    schema_name = f'{SCHEMA_PREFIX}group1_simple'
+    table_name = 'TableB'
+    restriction = dict(a_id=0, b_id=11)
+    vm = dj.VirtualModule('group1_simple', schema_name)
+    REST_response = client.post(
+        '/delete_tuple',
+        headers=dict(Authorization=f'Bearer {token}'),
+        json=dict(schemaName=schema_name,
+                  tableName=table_name,
+                  restrictionTuple=restriction))
+    assert REST_response.status_code == 409
+    assert REST_response.json['child_schema'] == f'{SCHEMA_PREFIX}group1_simple'
+    assert REST_response.json['child_table'] == 'TableC'
+    assert len(getattr(vm, table_name) & restriction) == 1
+    assert len(getattr(vm, 'TableC') & restriction) == 2
+
+
+def test_delete_independent_without_cascade(token, client, connection, schemas_simple):
+    schema_name = f'{SCHEMA_PREFIX}group1_simple'
+    table_name = 'TableB'
+    restriction = dict(a_id=1, b_id=21)
+    vm = dj.VirtualModule('group1_simple', schema_name)
+    REST_response = client.post(
+        '/delete_tuple?cascade=fAlSe',
+        headers=dict(Authorization=f'Bearer {token}'),
+        json=dict(schemaName=schema_name,
+                  tableName=table_name,
+                  restrictionTuple=restriction))
+    assert REST_response.status_code == 200
+    assert len(getattr(vm, table_name) & restriction) == 0
+
+
+def test_delete_invalid(token, client, connection, schemas_simple):
+    schema_name = f'{SCHEMA_PREFIX}group1_simple'
+    table_name = 'TableB'
+    restriction = dict()
+    vm = dj.VirtualModule('group1_simple', schema_name)
+    REST_response = client.post(
+        '/delete_tuple?cascade=TRUE',
+        headers=dict(Authorization=f'Bearer {token}'),
+        json=dict(schemaName=schema_name,
+                  tableName=table_name,
+                  restrictionTuple=restriction))
+    assert REST_response.status_code == 500
+    assert b'Restriction is invalid' in REST_response.data
+    assert len(getattr(vm, table_name)()) == 3

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -7,7 +7,6 @@ def test_delete_dependent_with_cascade(token, client, connection, schemas_simple
     table_name = 'TableB'
     restriction = dict(a_id=0, b_id=11)
     vm = dj.VirtualModule('group1_simple', schema_name)
-    print(getattr(vm, table_name) & restriction)
     REST_response = client.post(
         '/delete_tuple?cascade=tRuE',
         headers=dict(Authorization=f'Bearer {token}'),

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,123 +1,42 @@
-from os import getenv
-import pytest
-from pharus.server import app
-import datajoint as dj
 from base64 import b64encode
 from json import dumps
+from . import SCHEMA_PREFIX, client, token, group1_token, connection, schemas_simple
 
 
-@pytest.fixture
-def client():
-    with app.test_client() as client:
-        yield client
-
-
-@pytest.fixture
-def token(client):
-    yield client.post('/login', json=dict(databaseAddress=getenv('TEST_DB_SERVER'),
-                                              username=getenv('TEST_DB_USER'),
-                                              password=getenv('TEST_DB_PASS'))).json['jwt']
-
-
-@pytest.fixture
-def connection():
-    dj.config['safemode'] = False
-    connection = dj.conn(host=getenv('TEST_DB_SERVER'),
-                         user=getenv('TEST_DB_USER'),
-                         password=getenv('TEST_DB_PASS'), reset=True)
-    connection.query("""
-                     CREATE USER IF NOT EXISTS 'underprivileged'@'%%'
-                     IDENTIFIED BY 'datajoint';
-                     """)
-    connection.query("GRANT ALL PRIVILEGES ON `deps`.* TO 'underprivileged'@'%%';")
-    deps_secret = dj.VirtualModule('deps_secret', 'deps_secret', create_tables=True)
-    deps = dj.VirtualModule('deps', 'deps', create_tables=True)
-    @deps.schema
-    class TableA(dj.Lookup):
-        definition = """
-        a_id: int
-        ---
-        a_name: varchar(30)
-        """
-        contents = [(0, 'Raphael',), (1, 'Bernie',)]
-
-    @deps.schema
-    class TableB(dj.Lookup):
-        definition = """
-        -> TableA
-        b_id: int
-        ---
-        b_number: float
-        """
-        contents = [(0, 10, 22.12), (0, 11, -1.21,), (1, 21, 7.77,)]
-    deps = dj.VirtualModule('deps', 'deps', create_tables=True)
-
-    @deps_secret.schema
-    class DiffTableB(dj.Lookup):
-        definition = """
-        -> deps.TableA
-        bs_id: int
-        ---
-        bs_number: float
-        """
-        contents = [(0, -10, -99.99), (0, -11, 287.11,)]
-
-    @deps.schema
-    class TableC(dj.Lookup):
-        definition = """
-        -> TableB
-        c_id: int
-        ---
-        c_int: int
-        """
-        contents = [(0, 10, 100, -8), (0, 11, 200, -9,), (0, 11, 300, -7,)]
-
-    yield connection
-
-    deps_secret.schema.drop()
-    deps.schema.drop()
-    connection.query("DROP USER 'underprivileged'@'%%';")
-    connection.close()
-    dj.config['safemode'] = True
-
-
-@pytest.fixture
-def underprivileged_token(client, connection):
-    yield client.post('/login', json=dict(databaseAddress=getenv('TEST_DB_SERVER'),
-                                              username='underprivileged',
-                                              password='datajoint')).json['jwt']
-
-
-def test_dependencies_underprivileged(underprivileged_token, client):
-    schema_name = 'deps'
+def test_dependencies_underprivileged(group1_token, client, schemas_simple):
+    schema_name = f'{SCHEMA_PREFIX}group1_simple'
     table_name = 'TableA'
     restriction = b64encode(dumps(dict(a_id=0)).encode('utf-8')).decode('utf-8')
     REST_dependencies = client.get(
         f"""/record/dependency?schemaName={
             schema_name}&tableName={table_name}&restriction={restriction}""",
-        headers=dict(Authorization=f'Bearer {underprivileged_token}')).json['dependencies']
+        headers=dict(Authorization=f'Bearer {group1_token}')).json['dependencies']
     REST_records = client.post('/fetch_tuples',
-                               headers=dict(Authorization=f'Bearer {underprivileged_token}'),
+                               headers=dict(Authorization=f'Bearer {group1_token}'),
                                json=dict(schemaName=schema_name,
                                          tableName=table_name)).json['tuples']
     assert len(REST_records) == 2
     assert len(REST_dependencies) == 4
     table_a = [el for el in REST_dependencies
-               if el['schema'] == 'deps' and 'table_a' in el['table']][0]
+               if (el['schema'] == f'{SCHEMA_PREFIX}group1_simple' and
+                   'table_a' in el['table'])][0]
     assert table_a['accessible'] and table_a['count'] == 1
     table_b = [el for el in REST_dependencies
-               if el['schema'] == 'deps' and 'table_b' in el['table']][0]
+               if (el['schema'] == f'{SCHEMA_PREFIX}group1_simple' and
+                   'table_b' in el['table'])][0]
     assert table_b['accessible'] and table_b['count'] == 2
     table_c = [el for el in REST_dependencies
-               if el['schema'] == 'deps' and 'table_c' in el['table']][0]
+               if (el['schema'] == f'{SCHEMA_PREFIX}group1_simple' and
+                   'table_c' in el['table'])][0]
     assert table_c['accessible'] and table_c['count'] == 3
     diff_table_b = [el for el in REST_dependencies
-                    if el['schema'] == 'deps_secret' and 'diff_table_b' in el['table']][0]
+                    if (el['schema'] == f'{SCHEMA_PREFIX}group2_simple' and
+                        'diff_table_b' in el['table'])][0]
     assert not diff_table_b['accessible']
 
 
-def test_dependencies_admin(token, client, connection):
-    schema_name = 'deps'
+def test_dependencies_admin(token, client, schemas_simple):
+    schema_name = f'{SCHEMA_PREFIX}group1_simple'
     table_name = 'TableA'
     restriction = b64encode(dumps(dict(a_id=0)).encode('utf-8')).decode('utf-8')
     REST_dependencies = client.get(
@@ -131,14 +50,18 @@ def test_dependencies_admin(token, client, connection):
     assert len(REST_records) == 2
     assert len(REST_dependencies) == 4
     table_a = [el for el in REST_dependencies
-               if el['schema'] == 'deps' and 'table_a' in el['table']][0]
+               if (el['schema'] == f'{SCHEMA_PREFIX}group1_simple' and
+                   'table_a' in el['table'])][0]
     assert table_a['accessible'] and table_a['count'] == 1
     table_b = [el for el in REST_dependencies
-               if el['schema'] == 'deps' and 'table_b' in el['table']][0]
+               if (el['schema'] == f'{SCHEMA_PREFIX}group1_simple'and
+                   'table_b' in el['table'])][0]
     assert table_b['accessible'] and table_b['count'] == 2
     table_c = [el for el in REST_dependencies
-               if el['schema'] == 'deps' and 'table_c' in el['table']][0]
+               if (el['schema'] == f'{SCHEMA_PREFIX}group1_simple' and
+                   'table_c' in el['table'])][0]
     assert table_c['accessible'] and table_c['count'] == 3
     diff_table_b = [el for el in REST_dependencies
-                    if el['schema'] == 'deps_secret' and 'diff_table_b' in el['table']][0]
+                    if (el['schema'] == f'{SCHEMA_PREFIX}group2_simple' and
+                        'diff_table_b' in el['table'])][0]
     assert diff_table_b['accessible'] and diff_table_b['count'] == 2

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,21 +1,6 @@
 from pharus import __version__ as version
-import pytest
-from pharus.server import app
-from pharus.interface import DJConnector
-from os import getenv
-
-
-@pytest.fixture
-def client():
-    with app.test_client() as client:
-        yield client
+from . import client
 
 
 def test_version(client):
     assert client.get('/version').data.decode() == version
-
-
-def test_connect():
-    assert DJConnector.attempt_login(database_address=getenv('TEST_DB_SERVER'),
-                                     username=getenv('TEST_DB_USER'),
-                                     password=getenv('TEST_DB_PASS'))['result']

--- a/tests/test_table_metadata.py
+++ b/tests/test_table_metadata.py
@@ -1,0 +1,16 @@
+from . import SCHEMA_PREFIX, client, token, connection, schemas_simple
+
+
+def test_definition(token, client, schemas_simple):
+    simple1, simple2 = schemas_simple
+    REST_definition = client.post('/get_table_definition',
+                                  headers=dict(Authorization=f'Bearer {token}'),
+                                  json=dict(schemaName=simple1.database,
+                                            tableName='TableB')).data
+    assert f'{simple1.database}.TableA' in REST_definition.decode('utf-8')
+
+    REST_definition = client.post('/get_table_definition',
+                                  headers=dict(Authorization=f'Bearer {token}'),
+                                  json=dict(schemaName=simple2.database,
+                                            tableName='DiffTableB')).data
+    assert f'`{simple1.database}`.`#table_a`' in REST_definition.decode('utf-8')


### PR DESCRIPTION
- Remove CRUD references. (Fix #84)
- Replace unnecessary `snake_to_camel_case` method with `datajoint.utils.to_camel_case`.
- Replace `schema_virtual_module` term for table information. (Fix #85)
- Allow `cascade` argument for delete operations. Defaults to `false`. When a delete is attempted on a record with a foreign key reference, returns status code of `409` with parsed result like so:
  ```json
  {
    "error": "IntegrityError",
    "error_msg": "Full exception message goes here, blah, blah, ...",
    "child_schema": "alpha_company",
    "child_table": "Employee"
  }
  ```
  Otherwise will return `200` as before when successful or `500` for unhandled exceptions. (Fix #86)
- Add documentation related to bearer token security issue when deploying on a server. (Fix #83)
- Consolidate/Optimize fixtures for reuse in tests.
- Increased code coverage to `81%`.