### PR TITLE
Apply resource naming convention updates

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           export PHARUS_VERSION=$(cat pharus/version.py | tail -1 | awk -F\' '{print $2}')
           export HOST_UID=$(id -u)
-          docker-compose -f docker-compose-docs.yaml up --exit-code-from pharus --build
+          docker-compose -f docker-compose-docs.yaml up --exit-code-from pharus-docs --build
           echo "PHARUS_VERSION=${PHARUS_VERSION}" >> $GITHUB_ENV
       - name: Add docs static artifacts
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [Unreleased]
+## [0.1.0] - 2021-03-31
 ### Changed
 - Update `datajoint` to newly released `0.13.0`.
 
@@ -54,7 +54,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Support for DataJoint attribute types: `varchar`, `int`, `float`, `datetime`, `date`, `time`, `decimal`, `uuid`.
 - Check dependency utility to determine child table references.
 
-[Unreleased]: https://github.com/datajoint/pharus/compare/0.1.0b2...HEAD
+[0.1.0]: https://github.com/datajoint/pharus/compare/0.1.0b2...0.1.0
 [0.1.0b2]: https://github.com/datajoint/pharus/compare/0.1.0b0...0.1.0b2
 [0.1.0b0]: https://github.com/datajoint/pharus/compare/0.1.0a5...0.1.0b0
 [0.1.0a5]: https://github.com/datajoint/pharus/releases/tag/0.1.0a5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 ## [0.1.0] - 2021-03-31
 ### Changed
-- Update `datajoint` to newly released `0.13.0`.
+- Update `datajoint` to newly released `0.13.0`. PR #97
 
 ## [0.1.0b2] - 2021-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,20 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
 ## [0.1.0] - 2021-03-31
+### Added
+- Local database instance pre-populated with sample data for `dev` Docker Compose environment. PR #99
+- Capability to insert multiple, update multiple, and delete multiple. PR #99
+- Allow dependency restriction to include secondary attributes from parent table. PR #99
+
 ### Changed
 - Update `datajoint` to newly released `0.13.0`. PR #97
+- Rename service `pharus` to `pharus-docs` in `docs` Docker Compose environment to allow simulataneous development. PR #99
+- Update NGINX reverse proxy image reference. PR #99
+- Refactored API design to align with common REST resource naming convention. (#38) PR #99
+- Hide classes and methods that are internal and subject to change. PR #99
+
+### Removed
+- `InvalidDeleteRequest` exception is no longer available as it is now allowed to delete more than 1 record at a time. PR #99
 
 ## [0.1.0b2] - 2021-03-12
 

--- a/README.rst
+++ b/README.rst
@@ -33,13 +33,13 @@ To start the API server, use the command:
 
     .. code-block:: bash
 
-        PHARUS_VERSION=0.1.0b2 docker-compose -f docker-compose-deploy.yaml up -d
+        PHARUS_VERSION=0.1.0 docker-compose -f docker-compose-deploy.yaml up -d
 
 To stop the API server, use the command:
 
     .. code-block:: bash
 
-        PHARUS_VERSION=0.1.0b2 docker-compose -f docker-compose-deploy.yaml down
+        PHARUS_VERSION=0.1.0 docker-compose -f docker-compose-deploy.yaml down
 
 References
 ----------

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,6 @@
 User Documentation
 ==================
 
-.. warning::
-
-    The Pharus project is still early in its life and the maintainers are currently actively developing with a priority of addressing first critical issues directly related to the deliveries of `Alpha <https://github.com/datajoint/pharus/milestone/1>`_ and `Beta <https://github.com/datajoint/pharus/milestone/2>`_ milestones. Please be advised that while working through our milestones, we may restructure/refactor the codebase without warning until we issue our `Official Release <https://github.com/datajoint/pharus/milestone/3>`_ currently planned as ``0.1.0`` on ``2021-03-31``.
-
 ``pharus`` is a generic REST API server backend for `DataJoint <https://datajoint.io>`_ pipelines built on top of ``flask``, ``datajoint``, and ``pyjwt``.
 
 - `Documentation <https://datajoint.github.io/pharus>`_

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -1,5 +1,5 @@
-# PHARUS_VERSION=0.1.0b2 docker-compose -f docker-compose-deploy.yaml pull
-# PHARUS_VERSION=0.1.0b2 docker-compose -f docker-compose-deploy.yaml up -d
+# PHARUS_VERSION=0.1.0 docker-compose -f docker-compose-deploy.yaml pull
+# PHARUS_VERSION=0.1.0 docker-compose -f docker-compose-deploy.yaml up -d
 #
 # Intended for production deployment.
 # Note: You must run both commands above for minimal outage

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -20,7 +20,7 @@ services:
     #   - PHARUS_PREFIX=/
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.0.15
+    image: datajoint/nginx:v0.0.16
     environment:
       - ADD_pharus_TYPE=REST
       - ADD_pharus_ENDPOINT=pharus:5000

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -11,6 +11,13 @@ x-net: &net
   networks:
       - main
 services:
+  local-db:
+    <<: *net
+    image: datajoint/mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=pharus
+    volumes:
+      - ./tests/init/init.sql:/docker-entrypoint-initdb.d/init.sql
   pharus:
     <<: *net
     extends:
@@ -21,6 +28,9 @@ services:
     volumes:
       - ./pharus:/opt/conda/lib/python3.8/site-packages/pharus
     command: pharus
+    depends_on:
+      local-db:
+        condition: service_healthy
   fakeservices.datajoint.io:
     <<: *net
     image: datajoint/nginx:v0.0.16

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -23,7 +23,7 @@ services:
     command: pharus
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.0.15
+    image: datajoint/nginx:v0.0.16
     environment:
       - ADD_pharus_TYPE=REST
       - ADD_pharus_ENDPOINT=pharus:5000

--- a/docker-compose-docs.yaml
+++ b/docker-compose-docs.yaml
@@ -1,9 +1,9 @@
-# PY_VER=3.8 IMAGE=djtest DISTRO=alpine HOST_UID=$(id -u) docker-compose -f docker-compose-docs.yaml up --exit-code-from pharus --build
+# PY_VER=3.8 IMAGE=djtest DISTRO=alpine HOST_UID=$(id -u) docker-compose -f docker-compose-docs.yaml up --exit-code-from pharus-docs --build
 #
 # Used to build documentation artifacts.
 version: "2.4"
 services:
-  pharus:
+  pharus-docs:
     image: datajoint/${IMAGE}:py${PY_VER}-${DISTRO}
     user: ${HOST_UID}:anaconda
     volumes:

--- a/pharus/error.py
+++ b/pharus/error.py
@@ -6,6 +6,6 @@ class UnsupportedTableType(Exception):
     pass
 
 
-class InvalidDeleteRequest(Exception):
-    """Exception raised when attempting to delete 0 records."""
+class InvalidRestriction(Exception):
+    """Exception raised when restrictions result in no records when expected at least one."""
     pass

--- a/pharus/error.py
+++ b/pharus/error.py
@@ -6,11 +6,6 @@ class UnsupportedTableType(Exception):
     pass
 
 
-class InvalidRestriction(Exception):
-    """Exception raised when restrictions result in no records when expected at least one."""
-    pass
-
-
 class InvalidDeleteRequest(Exception):
-    """Exception raised when attempting to delete >1 or <1 records."""
+    """Exception raised when attempting to delete 0 records."""
     pass

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -195,7 +195,7 @@ class _DJConnector():
         :param table_name: Table name under the given schema; must be in camel case
         :type table_name: str
         :return: Dict with keys ``attribute_headers`` and ``attributes`` containing
-            ``primary_attributes``, ``secondary_attributes`` which each contain a
+            ``primary``, ``secondary`` which each contain a
             ``list`` of ``tuples`` specifying: ``attribute_name``, ``type``, ``nullable``,
             ``default``, ``autoincrement``.
         :rtype: dict

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -250,7 +250,7 @@ class DJConnector():
                     attribute_info.autoincrement
                     ))
 
-        return dict(attribute_header=['name', 'type', 'nullable', 'default', 'autoincrement'], attributes=table_attributes, table_definition=table.describe())
+        return dict(attributeHeader=['name', 'type', 'nullable', 'default', 'autoincrement'], attributes=table_attributes, tableDefinition=table.describe())
 
     # @staticmethod
     # def get_table_definition(jwt_payload: dict, schema_name: str, table_name: str) -> str:

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -373,11 +373,11 @@ class DJConnector():
 
         # Check to see if the restriction has at least one matching attribute, if not raise an
         # error
-        if len(table_attributes & tuple_to_restrict_by.keys()) == 0:
+        if len(table_attributes & restriction.keys()) == 0:
             raise InvalidRestriction('Restriction is invalid: None of the attributes match')
 
         # Compute restriction
-        tuple_to_delete = getattr(schema_virtual_module, table_name) & tuple_to_restrict_by
+        tuple_to_delete = getattr(schema_virtual_module, table_name) & restriction
 
         # Check if there is only 1 tuple to delete otherwise raise error
         if len(tuple_to_delete) > 1:

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -5,7 +5,6 @@ from datajoint.user_tables import UserTable
 from datajoint import VirtualModule
 import datetime
 import numpy as np
-from functools import reduce
 from .error import InvalidDeleteRequest, InvalidRestriction, UnsupportedTableType
 
 DAY = 24 * 60 * 60
@@ -16,7 +15,7 @@ class DJConnector():
     """Primary connector that communicates with a DataJoint database server."""
 
     @staticmethod
-    def attempt_login(database_address: str, username: str, password: str) -> dict:
+    def attempt_login(database_address: str, username: str, password: str):
         """
         Attempts to authenticate against database with given username and address.
 
@@ -26,9 +25,6 @@ class DJConnector():
         :type username: str
         :param password: Password of user
         :type password: str
-        :return: Dictionary with keys: result (``True`` | ``False``), and error (if
-            applicable)
-        :rtype: dict
         """
         dj.config['database.host'] = database_address
         dj.config['database.user'] = username
@@ -36,7 +32,6 @@ class DJConnector():
 
         # Attempt to connect return true if successful, false is failed
         dj.conn(reset=True)
-        return dict(result=True)
 
     @staticmethod
     def list_schemas(jwt_payload: dict) -> list:
@@ -77,11 +72,9 @@ class DJConnector():
 
         # Get list of tables names
         tables_name = dj.Schema(schema_name, create_schema=False).list_tables()
-
         # Dict to store list of table name for each type
-        tables_dict_list = dict(manual_tables=[], lookup_tables=[], computed_tables=[],
-                                imported_tables=[], part_tables=[])
-
+        tables_dict_list = dict(manual=[], lookup=[], computed=[],
+                                imported=[], part=[])
         # Loop through each table name to figure out what type it is and add them to
         # tables_dict_list
         for table_name in tables_name:
@@ -102,7 +95,6 @@ class DJConnector():
                     to_camel_case(table_name_parts[-1]))
             else:
                 raise UnsupportedTableType(table_name + ' is of unknown table type')
-
         return tables_dict_list
 
     @staticmethod
@@ -132,24 +124,6 @@ class DJConnector():
         :return: Records in dict form and the total number of records that can be paged
         :rtype: tuple
         """
-        def filter_to_restriction(attribute_filter: dict) -> str:
-            if attribute_filter['operation'] in ('>', '<', '>=', '<='):
-                operation = attribute_filter['operation']
-            elif attribute_filter['value'] is None:
-                operation = (' IS ' if attribute_filter['operation'] == '='
-                             else ' IS NOT ')
-            else:
-                operation = attribute_filter['operation']
-
-            if (isinstance(attribute_filter['value'], str) and
-                    not attribute_filter['value'].isnumeric()):
-                value = f"'{attribute_filter['value']}'"
-            else:
-                value = ('NULL' if attribute_filter['value'] is None
-                         else attribute_filter['value'])
-
-            return f"{attribute_filter['attributeName']}{operation}{value}"
-
         DJConnector.set_datajoint_config(jwt_payload)
 
         schema_virtual_module = dj.create_virtual_module(schema_name, schema_name)
@@ -159,8 +133,8 @@ class DJConnector():
 
         # Fetch tuples without blobs as dict to be used to create a
         #   list of tuples for returning
-        query = reduce(lambda q1, q2: q1 & q2, [table()] + [filter_to_restriction(f)
-                                                            for f in restriction])
+        query = table & dj.AndList([DJConnector.filter_to_restriction(f)
+                                    for f in restriction])
         non_blobs_rows = query.fetch(*table.heading.non_blobs, as_dict=True, limit=limit,
                                      offset=(page-1)*limit, order_by=order)
 
@@ -205,7 +179,7 @@ class DJConnector():
 
             # Add the row list to tuples
             rows.append(row)
-        return table.heading.attributes.keys(), rows, len(query)
+        return list(table.heading.attributes.keys()), rows, len(query)
 
     @staticmethod
     def get_table_attributes(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
@@ -250,28 +224,28 @@ class DJConnector():
                     attribute_info.autoincrement
                     ))
 
-        return dict(attributeHeader=['name', 'type', 'nullable', 'default', 'autoincrement'], attributes=table_attributes, tableDefinition=table.describe())
+        return dict(attributeHeader=['name', 'type', 'nullable', 'default', 'autoincrement'], attributes=table_attributes)
 
-    # @staticmethod
-    # def get_table_definition(jwt_payload: dict, schema_name: str, table_name: str) -> str:
-    #     """
-    #     Get the table definition.
+    @staticmethod
+    def get_table_definition(jwt_payload: dict, schema_name: str, table_name: str) -> str:
+        """
+        Get the table definition.
 
-    #     :param jwt_payload: Dictionary containing databaseAddress, username, and password
-    #         strings
-    #     :type jwt_payload: dict
-    #     :param schema_name: Name of schema to list all tables from
-    #     :type schema_name: str
-    #     :param table_name: Table name under the given schema; must be in camel case
-    #     :type table_name: str
-    #     :return: Definition of the table
-    #     :rtype: str
-    #     """
-    #     DJConnector.set_datajoint_config(jwt_payload)
+        :param jwt_payload: Dictionary containing databaseAddress, username, and password
+            strings
+        :type jwt_payload: dict
+        :param schema_name: Name of schema to list all tables from
+        :type schema_name: str
+        :param table_name: Table name under the given schema; must be in camel case
+        :type table_name: str
+        :return: Definition of the table
+        :rtype: str
+        """
+        DJConnector.set_datajoint_config(jwt_payload)
 
-    #     local_values = locals()
-    #     local_values[schema_name] = dj.VirtualModule(schema_name, schema_name)
-    #     return getattr(local_values[schema_name], table_name).describe()
+        local_values = locals()
+        local_values[schema_name] = dj.VirtualModule(schema_name, schema_name)
+        return getattr(local_values[schema_name], table_name).describe()
 
     @staticmethod
     def insert_tuple(jwt_payload: dict, schema_name: str, table_name: str,
@@ -292,7 +266,7 @@ class DJConnector():
         DJConnector.set_datajoint_config(jwt_payload)
 
         schema_virtual_module = dj.create_virtual_module(schema_name, schema_name)
-        getattr(schema_virtual_module, table_name).insert1(tuple_to_insert)
+        getattr(schema_virtual_module, table_name).insert(tuple_to_insert)
 
     @staticmethod
     def record_dependency(jwt_payload: dict, schema_name: str, table_name: str,
@@ -341,11 +315,11 @@ class DJConnector():
         DJConnector.set_datajoint_config(jwt_payload)
 
         schema_virtual_module = dj.create_virtual_module(schema_name, schema_name)
-        getattr(schema_virtual_module, table_name).update1(tuple_to_update)
+        [getattr(schema_virtual_module, table_name).update1(t) for t in tuple_to_update]
 
     @staticmethod
     def delete_tuple(jwt_payload: dict, schema_name: str, table_name: str,
-                     restriction: dict, cascade: bool = False):
+                     restriction: list = [], cascade: bool = False):
         """
         Delete a specific record based on the restriction given (supports only deleting one at
         a time).
@@ -365,29 +339,21 @@ class DJConnector():
         DJConnector.set_datajoint_config(jwt_payload)
 
         schema_virtual_module = dj.create_virtual_module(schema_name, schema_name)
-        # Get all the table attributes and create a set
-        table_attributes = set(getattr(schema_virtual_module,
-                                       table_name).heading.primary_key +
-                               getattr(schema_virtual_module,
-                                       table_name).heading.secondary_attributes)
 
-        # Check to see if the restriction has at least one matching attribute, if not raise an
-        # error
-        if len(table_attributes & restriction.keys()) == 0:
-            raise InvalidRestriction('Restriction is invalid: None of the attributes match')
+        # Get table object from name
+        table = DJConnector.get_table_object(schema_virtual_module, table_name)
+
+        restrictions = [DJConnector.filter_to_restriction(f) for f in restriction]
 
         # Compute restriction
-        tuple_to_delete = getattr(schema_virtual_module, table_name) & restriction
+        query = table & dj.AndList(restrictions)
 
         # Check if there is only 1 tuple to delete otherwise raise error
-        if len(tuple_to_delete) > 1:
-            raise InvalidDeleteRequest("""Cannot delete more than 1 tuple at a time.
-                            Please update the restriction accordingly""")
-        elif len(tuple_to_delete) == 0:
+        if len(query) == 0:
             raise InvalidDeleteRequest('Nothing to delete')
 
         # All check pass thus proceed to delete
-        tuple_to_delete.delete(safemode=False) if cascade else tuple_to_delete.delete_quick()
+        query.delete(safemode=False) if cascade else query.delete_quick()
 
     @staticmethod
     def get_table_object(schema_virtual_module: VirtualModule, table_name: str) -> UserTable:
@@ -408,6 +374,25 @@ class DJConnector():
                            table_name_parts[1])
         else:
             return getattr(schema_virtual_module, table_name_parts[0])
+
+    @staticmethod
+    def filter_to_restriction(attribute_filter: dict) -> str:
+        if attribute_filter['operation'] in ('>', '<', '>=', '<='):
+            operation = attribute_filter['operation']
+        elif attribute_filter['value'] is None:
+            operation = (' IS ' if attribute_filter['operation'] == '='
+                            else ' IS NOT ')
+        else:
+            operation = attribute_filter['operation']
+
+        if (isinstance(attribute_filter['value'], str) and
+                not attribute_filter['value'].isnumeric()):
+            value = f"'{attribute_filter['value']}'"
+        else:
+            value = ('NULL' if attribute_filter['value'] is None
+                        else attribute_filter['value'])
+
+        return f"{attribute_filter['attributeName']}{operation}{value}"
 
     @staticmethod
     def set_datajoint_config(jwt_payload: dict):

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -345,7 +345,7 @@ class DJConnector():
 
     @staticmethod
     def delete_tuple(jwt_payload: dict, schema_name: str, table_name: str,
-                     tuple_to_restrict_by: dict, cascade: bool = False):
+                     restriction: dict, cascade: bool = False):
         """
         Delete a specific record based on the restriction given (supports only deleting one at
         a time).

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -5,7 +5,7 @@ from datajoint.user_tables import UserTable
 from datajoint import VirtualModule
 import datetime
 import numpy as np
-from .error import InvalidDeleteRequest, UnsupportedTableType
+from .error import InvalidRestriction, UnsupportedTableType
 
 DAY = 24 * 60 * 60
 DEFAULT_FETCH_LIMIT = 1000  # Stop gap measure to deal with super large tables
@@ -359,7 +359,7 @@ class _DJConnector():
         query = table & dj.AndList(restrictions)
         # Check if there is only 1 tuple to delete otherwise raise error
         if len(query) == 0:
-            raise InvalidDeleteRequest('Nothing to delete')
+            raise InvalidRestriction('Nothing to delete')
 
         # All check pass thus proceed to delete
         query.delete(safemode=False) if cascade else query.delete_quick()

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -318,9 +318,9 @@ def table(jwt_payload: dict) -> dict:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/fetch_tuples", methods=['POST'])
+@app.route(f"{environ.get('PHARUS_PREFIX', '')}/record", methods=['GET'])
 @protected_route
-def fetch_tuples(jwt_payload: dict) -> dict:
+def record(jwt_payload: dict) -> dict:
     ("""
     Handler for ``/fetch_tuple`` route.
 
@@ -416,8 +416,8 @@ def fetch_tuples(jwt_payload: dict) -> dict:
     try:
         table_tuples, total_count = DJConnector.fetch_tuples(
             jwt_payload=jwt_payload,
-            schema_name=request.json["schemaName"],
-            table_name=request.json["tableName"],
+            schema_name=request.args["schemaName"],
+            table_name=request.args["tableName"],
             **{k: (int(v) if k in ('limit', 'page')
                    else (v.split(',') if k == 'order' else loads(
                        b64decode(v.encode('utf-8')).decode('utf-8'))))

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -243,9 +243,9 @@ def schema(jwt_payload: dict) -> dict:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/list_tables", methods=['POST'])
+@app.route(f"{environ.get('PHARUS_PREFIX', '')}/table", methods=['GET'])
 @protected_route
-def list_tables(jwt_payload: dict) -> dict:
+def table(jwt_payload: dict) -> dict:
     """
     Handler for ``/list_tables`` route.
 
@@ -309,11 +309,13 @@ def list_tables(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """
-    try:
-        tables_dict_list = DJConnector.list_tables(jwt_payload, request.json["schemaName"])
-        return dict(tableTypeAndNames=tables_dict_list)
-    except Exception as e:
-        return str(e), 500
+    if request.method == 'GET':
+        try:
+            tables_dict_list = DJConnector.list_tables(jwt_payload,
+                                                       request.args["schemaName"])
+            return dict(tableTypeAndNames=tables_dict_list)
+        except Exception as e:
+            return str(e), 500
 
 
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/fetch_tuples", methods=['POST'])

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -90,7 +90,7 @@ def api_version() -> str:
 
         :statuscode 200: No error.
     """
-    if request.method == 'GET':
+    if request.method in {'GET', 'HEAD'}:
         return dict(version=version)
 
 
@@ -236,7 +236,7 @@ def schema(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """
-    if request.method == 'GET':
+    if request.method in {'GET', 'HEAD'}:
         # Get all the schemas
         try:
             schemas_name = DJConnector.list_schemas(jwt_payload)
@@ -311,7 +311,7 @@ def table(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """
-    if request.method == 'GET':
+    if request.method in {'GET', 'HEAD'}:
         try:
             tables_dict_list = DJConnector.list_tables(jwt_payload,
                                                        request.args["schemaName"])
@@ -415,7 +415,7 @@ def get_record(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """)
-    if request.method == 'GET':
+    if request.method in {'GET', 'HEAD'}:
         try:
             record_header, table_tuples, total_count = DJConnector.fetch_tuples(
                 jwt_payload=jwt_payload,
@@ -643,7 +643,7 @@ def get_table_attributes(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """
-    if request.method == 'GET':
+    if request.method in {'GET', 'HEAD'}:
         try:
             return DJConnector.get_table_attributes(jwt_payload,
                                                     request.args["schemaName"],
@@ -805,7 +805,7 @@ def record_dependency(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """)
-    if request.method == 'GET':
+    if request.method in {'GET', 'HEAD'}:
         # Get dependencies
         try:
             dependencies = DJConnector.record_dependency(

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -181,18 +181,18 @@ def login() -> dict:
         return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/list_schemas", methods=['GET'])
+@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema", methods=['GET'])
 @protected_route
-def list_schemas(jwt_payload: dict) -> dict:
+def schema(jwt_payload: dict) -> dict:
     """
-    Handler for ``/list_schemas`` route.
+    Handler for ``/schema`` route.
 
     :param jwt_payload: Dictionary containing databaseAddress, username, and password strings.
     :type jwt_payload: dict
     :return: If successful then sends back a list of schemas names otherwise returns error.
     :rtype: dict
 
-    .. http:get:: /list_schemas
+    .. http:get:: /schema
 
         Route to get list of schemas.
 
@@ -200,7 +200,7 @@ def list_schemas(jwt_payload: dict) -> dict:
 
         .. sourcecode:: http
 
-            GET /list_schemas HTTP/1.1
+            GET /schema HTTP/1.1
             Host: fakeservices.datajoint.io
 
         **Example successful response**:
@@ -234,12 +234,13 @@ def list_schemas(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """
-    # Get all the schemas
-    try:
-        schemas_name = DJConnector.list_schemas(jwt_payload)
-        return dict(schemaNames=schemas_name)
-    except Exception as e:
-        return str(e), 500
+    if request.method == 'GET':
+        # Get all the schemas
+        try:
+            schemas_name = DJConnector.list_schemas(jwt_payload)
+            return dict(schemaNames=schemas_name)
+        except Exception as e:
+            return str(e), 500
 
 
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/list_tables", methods=['POST'])

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -317,7 +317,9 @@ def table(jwt_payload: dict, schema_name: str) -> dict:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record", methods=['GET'])
+@app.route(
+    f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record",
+    methods=['GET'])
 @protected_route
 def get_record(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
     ("""
@@ -338,8 +340,8 @@ def get_record(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
         .. sourcecode:: http
 
             GET /record?schemaName=alpha_company&tableName=Computer&limit=2&page=1&"""
-     "order=computer_id%20DESC&restriction=W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLCAib3BlcmF0aW9uIjogIj49Iiw"
-     "gInZhbHVlIjogMzJ9XQo="
+     "order=computer_id%20DESC&restriction=W3siYXR0cmlidXRlTmFtZSI6ICJjb21wdXRlcl9tZW1vcnkiLC"
+     "Aib3BlcmF0aW9uIjogIj49IiwgInZhbHVlIjogMzJ9XQo="
      """ HTTP/1.1
             Host: fakeservices.datajoint.io
             Accept: application/json
@@ -423,12 +425,15 @@ def get_record(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
                         b64decode(v.encode('utf-8')).decode('utf-8'))))
                    for k, v in request.args.items()},
                 )
-            return dict(recordHeader=record_header, records=table_tuples, totalCount=total_count)
+            return dict(recordHeader=record_header, records=table_tuples,
+                        totalCount=total_count)
         except Exception as e:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/definition", methods=['GET'])
+@app.route(
+    f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/definition",
+    methods=['GET'])
 @protected_route
 def definition(jwt_payload: dict, schema_name: str, table_name: str) -> str:
     """
@@ -504,7 +509,9 @@ def definition(jwt_payload: dict, schema_name: str, table_name: str) -> str:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/attribute", methods=['GET'])
+@app.route(
+    f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/attribute",
+    methods=['GET'])
 @protected_route
 def get_table_attributes(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
     """
@@ -647,7 +654,9 @@ def get_table_attributes(jwt_payload: dict, schema_name: str, table_name: str) -
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record", methods=['POST'])
+@app.route(
+    f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record",
+    methods=['POST'])
 @protected_route
 def post_record(jwt_payload: dict, schema_name: str, table_name: str) -> str:
     """
@@ -721,13 +730,15 @@ s
             DJConnector.insert_tuple(jwt_payload,
                                      schema_name,
                                      table_name,
-                                     request.json["record"])
+                                     request.json["records"])
             return "Insert Successful"
         except Exception as e:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/dependency", methods=['GET'])
+@app.route(
+    f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/dependency",
+    methods=['GET'])
 @protected_route
 def record_dependency(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
     ("""
@@ -805,13 +816,16 @@ def record_dependency(jwt_payload: dict, schema_name: str, table_name: str) -> d
         try:
             dependencies = DJConnector.record_dependency(
                 jwt_payload, schema_name, table_name,
-                loads(b64decode(request.args.get('restriction').encode('utf-8')).decode('utf-8')))
+                loads(b64decode(
+                    request.args.get('restriction').encode('utf-8')).decode('utf-8')))
             return dict(dependencies=dependencies)
         except Exception as e:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record", methods=['PATCH'])
+@app.route(
+    f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record",
+    methods=['PATCH'])
 @protected_route
 def patch_record(jwt_payload: dict, schema_name: str, table_name: str) -> str:
     """
@@ -891,7 +905,9 @@ def patch_record(jwt_payload: dict, schema_name: str, table_name: str) -> str:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record", methods=['DELETE'])
+@app.route(
+    f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record",
+    methods=['DELETE'])
 @protected_route
 def delete_record(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
     """
@@ -977,7 +993,8 @@ def delete_record(jwt_payload: dict, schema_name: str, table_name: str) -> dict:
                                      schema_name,
                                      table_name,
                                      **{k: loads(b64decode(v.encode('utf-8')).decode('utf-8'))
-                                        for k, v in request.args.items() if k == 'restriction'},
+                                        for k, v in request.args.items()
+                                        if k == 'restriction'},
                                      **{k: v.lower() == 'true'
                                         for k, v in request.args.items() if k == 'cascade'},)
             return "Delete Sucessful"

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -723,9 +723,9 @@ def post_record(jwt_payload: dict) -> str:
         try:
             # Attempt to insert
             DJConnector.insert_tuple(jwt_payload,
-                                     request.args["schemaName"],
-                                     request.args["tableName"],
-                                     request.args["record"])
+                                     request.json["schemaName"],
+                                     request.json["tableName"],
+                                     request.json["record"])
             return "Insert Successful"
         except Exception as e:
             return str(e), 500
@@ -804,19 +804,20 @@ def record_dependency(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """)
-    # Get dependencies
-    try:
-        dependencies = DJConnector.record_dependency(
-            jwt_payload, request.args.get('schemaName'), request.args.get('tableName'),
-            loads(b64decode(request.args.get('restriction').encode('utf-8')).decode('utf-8')))
-        return dict(dependencies=dependencies)
-    except Exception as e:
-        return str(e), 500
+    if request.method == 'GET':
+        # Get dependencies
+        try:
+            dependencies = DJConnector.record_dependency(
+                jwt_payload, request.args.get('schemaName'), request.args.get('tableName'),
+                loads(b64decode(request.args.get('restriction').encode('utf-8')).decode('utf-8')))
+            return dict(dependencies=dependencies)
+        except Exception as e:
+            return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/update_tuple", methods=['POST'])
+@app.route(f"{environ.get('PHARUS_PREFIX', '')}/record", methods=['PATCH'])
 @protected_route
-def update_tuple(jwt_payload: dict) -> str:
+def patch_record(jwt_payload: dict) -> str:
     """
     Handler for ``/update_tuple`` route.
 
@@ -882,15 +883,16 @@ def update_tuple(jwt_payload: dict) -> str:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """
-    try:
-        # Attempt to insert
-        DJConnector.update_tuple(jwt_payload,
-                                 request.json["schemaName"],
-                                 request.json["tableName"],
-                                 request.json["tuple"])
-        return "Update Successful"
-    except Exception as e:
-        return str(e), 500
+    if request.method == 'PATCH':
+        try:
+            # Attempt to insert
+            DJConnector.update_tuple(jwt_payload,
+                                     request.json["schemaName"],
+                                     request.json["tableName"],
+                                     request.json["record"])
+            return "Update Successful"
+        except Exception as e:
+            return str(e), 500
 
 
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/delete_tuple", methods=['POST'])

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -426,7 +426,7 @@ def get_record(jwt_payload: dict) -> dict:
                         b64decode(v.encode('utf-8')).decode('utf-8'))))
                    for k, v in request.args.items() if k not in ('schemaName', 'tableName')},
                 )
-            return dict(record_header=record_header, records=table_tuples, total_count=total_count)
+            return dict(recordHeader=record_header, records=table_tuples, totalCount=total_count)
         except Exception as e:
             return str(e), 500
 
@@ -989,9 +989,9 @@ def delete_record(jwt_payload: dict) -> dict:
         except IntegrityError as e:
             match = foreign_key_error_regexp.match(e.args[0])
             return dict(error=e.__class__.__name__,
-                        error_msg=str(e),
-                        child_schema=match.group('child').split('.')[0][1:-1],
-                        child_table=to_camel_case(match.group('child').split('.')[1][1:-1]),
+                        errorMessage=str(e),
+                        childSchema=match.group('child').split('.')[0][1:-1],
+                        childTable=to_camel_case(match.group('child').split('.')[1][1:-1]),
                         ), 409
         except Exception as e:
             return str(e), 500

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -91,7 +91,7 @@ def api_version() -> str:
         :statuscode 200: No error.
     """
     if request.method == 'GET':
-        return version
+        return dict(version=version)
 
 
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/login", methods=['POST'])
@@ -315,7 +315,7 @@ def table(jwt_payload: dict) -> dict:
         try:
             tables_dict_list = DJConnector.list_tables(jwt_payload,
                                                        request.args["schemaName"])
-            return dict(tableTypeAndNames=tables_dict_list)
+            return dict(tableTypes=tables_dict_list)
         except Exception as e:
             return str(e), 500
 
@@ -417,7 +417,7 @@ def get_record(jwt_payload: dict) -> dict:
     """)
     if request.method == 'GET':
         try:
-            table_tuples, total_count = DJConnector.fetch_tuples(
+            record_header, table_tuples, total_count = DJConnector.fetch_tuples(
                 jwt_payload=jwt_payload,
                 schema_name=request.args["schemaName"],
                 table_name=request.args["tableName"],
@@ -426,88 +426,88 @@ def get_record(jwt_payload: dict) -> dict:
                         b64decode(v.encode('utf-8')).decode('utf-8'))))
                    for k, v in request.args.items() if k not in ('schemaName', 'tableName')},
                 )
-            return dict(tuples=table_tuples, total_count=total_count)
+            return dict(record_header=record_header, records=table_tuples, total_count=total_count)
         except Exception as e:
             return str(e), 500
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/get_table_definition", methods=['POST'])
-@protected_route
-def get_table_definition(jwt_payload: dict) -> str:
-    """
-    Handler for ``/get_table_definition`` route.
+# @app.route(f"{environ.get('PHARUS_PREFIX', '')}/get_table_definition", methods=['POST'])
+# @protected_route
+# def get_table_definition(jwt_payload: dict) -> str:
+#     """
+#     Handler for ``/get_table_definition`` route.
 
-    :param jwt_payload: Dictionary containing databaseAddress, username, and password strings.
-    :type jwt_payload: dict
-    :return: If successful then sends back definition for table otherwise returns error.
-    :rtype: dict
+#     :param jwt_payload: Dictionary containing databaseAddress, username, and password strings.
+#     :type jwt_payload: dict
+#     :return: If successful then sends back definition for table otherwise returns error.
+#     :rtype: dict
 
-    .. http:post:: /get_table_definition
+#     .. http:post:: /get_table_definition
 
-        Route to get DataJoint table definition.
+#         Route to get DataJoint table definition.
 
-        **Example request**:
+#         **Example request**:
 
-        .. sourcecode:: http
+#         .. sourcecode:: http
 
-            POST /get_table_definition HTTP/1.1
-            Host: fakeservices.datajoint.io
-            Accept: application/json
+#             POST /get_table_definition HTTP/1.1
+#             Host: fakeservices.datajoint.io
+#             Accept: application/json
 
-            {
-                "schemaName": "alpha_company",
-                "tableName": "Computer"
-            }
+#             {
+#                 "schemaName": "alpha_company",
+#                 "tableName": "Computer"
+#             }
 
-        **Example successful response**:
+#         **Example successful response**:
 
-        .. sourcecode:: http
+#         .. sourcecode:: http
 
-            HTTP/1.1 200 OK
-            Vary: Accept
-            Content-Type: text/plain
+#             HTTP/1.1 200 OK
+#             Vary: Accept
+#             Content-Type: text/plain
 
-            # Computers that belong to the company
-            computer_id          : uuid                     # unique id
-            ---
-            computer_serial      : varchar(9)               # manufacturer serial number
-            computer_brand       : enum('HP','Dell')        # manufacturer brand
-            computer_built       : date                     # manufactured date
-            computer_processor   : double                   # processing power in GHz
-            computer_memory      : int                      # RAM in GB
-            computer_weight      : float                    # weight in lbs
-            computer_cost        : decimal(6,2)             # purchased price
-            computer_preowned    : tinyint                  # purchased as new or used
-            computer_purchased   : datetime                 # purchased date and time
-            computer_updates=null : time                     # scheduled daily update timeslot
-
-
-        **Example unexpected response**:
-
-        .. sourcecode:: http
-
-            HTTP/1.1 500 Internal Server Error
-            Vary: Accept
-            Content-Type: text/plain
-
-            400 Bad Request: The browser (or proxy) sent a request that this server could not
-                understand.
-
-        :reqheader Authorization: Bearer <OAuth2_token>
-        :resheader Content-Type: text/plain
-        :statuscode 200: No error.
-        :statuscode 500: Unexpected error encountered. Returns the error message as a string.
-    """
-    try:
-        table_definition = DJConnector.get_table_definition(jwt_payload,
-                                                            request.json["schemaName"],
-                                                            request.json["tableName"])
-        return table_definition
-    except Exception as e:
-        return str(e), 500
+#             # Computers that belong to the company
+#             computer_id          : uuid                     # unique id
+#             ---
+#             computer_serial      : varchar(9)               # manufacturer serial number
+#             computer_brand       : enum('HP','Dell')        # manufacturer brand
+#             computer_built       : date                     # manufactured date
+#             computer_processor   : double                   # processing power in GHz
+#             computer_memory      : int                      # RAM in GB
+#             computer_weight      : float                    # weight in lbs
+#             computer_cost        : decimal(6,2)             # purchased price
+#             computer_preowned    : tinyint                  # purchased as new or used
+#             computer_purchased   : datetime                 # purchased date and time
+#             computer_updates=null : time                     # scheduled daily update timeslot
 
 
-@app.route(f"{environ.get('PHARUS_PREFIX', '')}/get_table_attributes", methods=['POST'])
+#         **Example unexpected response**:
+
+#         .. sourcecode:: http
+
+#             HTTP/1.1 500 Internal Server Error
+#             Vary: Accept
+#             Content-Type: text/plain
+
+#             400 Bad Request: The browser (or proxy) sent a request that this server could not
+#                 understand.
+
+#         :reqheader Authorization: Bearer <OAuth2_token>
+#         :resheader Content-Type: text/plain
+#         :statuscode 200: No error.
+#         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
+#     """
+#     try:
+#         table_definition = DJConnector.get_table_definition(jwt_payload,
+#                                                             request.json["schemaName"],
+#                                                             request.json["tableName"])
+#         return table_definition
+#     except Exception as e:
+#         return str(e), 500
+
+
+@app.route(f"{environ.get('PHARUS_PREFIX', '')}/attribute", methods=['GET'])
 @protected_route
 def get_table_attributes(jwt_payload: dict) -> dict:
     """
@@ -643,12 +643,13 @@ def get_table_attributes(jwt_payload: dict) -> dict:
         :statuscode 200: No error.
         :statuscode 500: Unexpected error encountered. Returns the error message as a string.
     """
-    try:
-        return DJConnector.get_table_attributes(jwt_payload,
-                                                request.json["schemaName"],
-                                                request.json["tableName"])
-    except Exception as e:
-        return str(e), 500
+    if request.method == 'GET':
+        try:
+            return DJConnector.get_table_attributes(jwt_payload,
+                                                    request.args["schemaName"],
+                                                    request.args["tableName"])
+        except Exception as e:
+            return str(e), 500
 
 
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/record", methods=['POST'])

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = '0.1.0b2'
+__version__ = '0.1.0'

--- a/tests/init/init.sql
+++ b/tests/init/init.sql
@@ -1,0 +1,46 @@
+CREATE DATABASE `alpha_company`;
+
+CREATE TABLE `alpha_company`.`~log` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'event order id',
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'event timestamp',
+  `version` varchar(12) NOT NULL COMMENT 'datajoint version',
+  `user` varchar(255) NOT NULL COMMENT 'user@host',
+  `host` varchar(255) NOT NULL DEFAULT '' COMMENT 'system hostname',
+  `event` varchar(255) NOT NULL DEFAULT '' COMMENT 'event message',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='event logging table for `alpha_company`';
+
+CREATE TABLE `alpha_company`.`computer` (
+  `computer_id` binary(16) NOT NULL COMMENT ':uuid:unique id',
+  `computer_serial` varchar(9) NOT NULL DEFAULT 'ABC101' COMMENT 'manufacturer serial number',
+  `computer_brand` enum('HP','Dell') NOT NULL COMMENT 'manufacturer brand',
+  `computer_built` date NOT NULL COMMENT 'manufactured date',
+  `computer_processor` double NOT NULL COMMENT 'processing power in GHz',
+  `computer_memory` int NOT NULL COMMENT 'RAM in GB',
+  `computer_weight` float NOT NULL COMMENT 'weight in lbs',
+  `computer_cost` decimal(6,2) NOT NULL COMMENT 'purchased price',
+  `computer_preowned` tinyint(1) NOT NULL COMMENT 'purchased as new or used',
+  `computer_purchased` datetime NOT NULL COMMENT 'purchased date and time',
+  `computer_updates` time DEFAULT NULL COMMENT 'scheduled daily update timeslot',
+  `computer_accessories` longblob COMMENT 'included additional accessories',
+  PRIMARY KEY (`computer_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Computers that belong to the company';
+
+INSERT INTO `alpha_company`.`computer` (computer_id, computer_serial, computer_brand, computer_built, computer_processor, computer_memory, computer_weight, computer_cost, computer_preowned, computer_purchased, computer_updates, computer_accessories)
+VALUES
+(X'4E41491A86D54AF7A01389BDE75528BD', 'DJS1JA17G', 'Dell', '2020-05-25', 2.2, 16, 4.4, 700.99, 0, '2020-10-20 08:04:21', NULL, NULL)
+,(X'DCD4CFD96791433CA805F391C289E6EA', 'HUA20K9LL', 'HP', '2020-07-12', 2.8, 32, 5.7, 693.54, 1, '2020-11-05 13:58:02', '23:30:05', X'646A30000403000000000000001400000000000000050B00000000000000706F7765725F6361626C6504000000000000000A0100010E000000000000000505000000000000006D6F75736504000000000000000A01000111000000000000000508000000000000006B6579626F61726404000000000000000A010001');
+
+CREATE TABLE `alpha_company`.`#employee` (
+  `computer_id` binary(16) NOT NULL COMMENT ':uuid:unique id',
+  `employee_name` varchar(30) NOT NULL COMMENT 'employee name',
+  PRIMARY KEY (`computer_id`),
+  CONSTRAINT `#employee_ibfk_1` FOREIGN KEY (`computer_id`) REFERENCES `alpha_company`.`computer` (`computer_id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Employees that are assigned a computer';
+
+INSERT INTO `alpha_company`.`#employee` (computer_id, employee_name)
+VALUES
+(X'4E41491A86D54AF7A01389BDE75528BD', 'Raphael Guzman')
+,(X'DCD4CFD96791433CA805F391C289E6EA', 'John Doe');
+
+CREATE DATABASE `empty`;

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,18 +1,22 @@
 from . import SCHEMA_PREFIX, token, client, connection, schemas_simple
 import datajoint as dj
+from json import dumps
+from base64 import b64encode
+from urllib.parse import urlencode
 
 
 def test_delete_dependent_with_cascade(token, client, connection, schemas_simple):
     schema_name = f'{SCHEMA_PREFIX}group1_simple'
     table_name = 'TableB'
     restriction = dict(a_id=0, b_id=11)
+    filters = [dict(attributeName=k, operation='=', value=v)
+               for k, v in restriction.items()]
+    encoded_filters = b64encode(dumps(filters).encode('utf-8')).decode('utf-8')
+    q = dict(cascade='tRuE', restriction=encoded_filters)
     vm = dj.VirtualModule('group1_simple', schema_name)
-    REST_response = client.post(
-        '/delete_tuple?cascade=tRuE',
-        headers=dict(Authorization=f'Bearer {token}'),
-        json=dict(schemaName=schema_name,
-                  tableName=table_name,
-                  restrictionTuple=restriction))
+    REST_response = client.delete(
+        f'/schema/{schema_name}/table/{table_name}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}'))
     assert REST_response.status_code == 200
     assert len(getattr(vm, table_name) & restriction) == 0
     assert len(getattr(vm, 'TableC') & restriction) == 0
@@ -22,16 +26,17 @@ def test_delete_dependent_without_cascade(token, client, connection, schemas_sim
     schema_name = f'{SCHEMA_PREFIX}group1_simple'
     table_name = 'TableB'
     restriction = dict(a_id=0, b_id=11)
+    filters = [dict(attributeName=k, operation='=', value=v)
+               for k, v in restriction.items()]
+    encoded_filters = b64encode(dumps(filters).encode('utf-8')).decode('utf-8')
+    q = dict(restriction=encoded_filters)
     vm = dj.VirtualModule('group1_simple', schema_name)
-    REST_response = client.post(
-        '/delete_tuple',
-        headers=dict(Authorization=f'Bearer {token}'),
-        json=dict(schemaName=schema_name,
-                  tableName=table_name,
-                  restrictionTuple=restriction))
+    REST_response = client.delete(
+        f'/schema/{schema_name}/table/{table_name}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}'))
     assert REST_response.status_code == 409
-    assert REST_response.json['child_schema'] == f'{SCHEMA_PREFIX}group1_simple'
-    assert REST_response.json['child_table'] == 'TableC'
+    assert REST_response.json['childSchema'] == f'{SCHEMA_PREFIX}group1_simple'
+    assert REST_response.json['childTable'] == 'TableC'
     assert len(getattr(vm, table_name) & restriction) == 1
     assert len(getattr(vm, 'TableC') & restriction) == 2
 
@@ -40,13 +45,14 @@ def test_delete_independent_without_cascade(token, client, connection, schemas_s
     schema_name = f'{SCHEMA_PREFIX}group1_simple'
     table_name = 'TableB'
     restriction = dict(a_id=1, b_id=21)
+    filters = [dict(attributeName=k, operation='=', value=v)
+               for k, v in restriction.items()]
+    encoded_filters = b64encode(dumps(filters).encode('utf-8')).decode('utf-8')
+    q = dict(cascade='fAlSe', restriction=encoded_filters)
     vm = dj.VirtualModule('group1_simple', schema_name)
-    REST_response = client.post(
-        '/delete_tuple?cascade=fAlSe',
-        headers=dict(Authorization=f'Bearer {token}'),
-        json=dict(schemaName=schema_name,
-                  tableName=table_name,
-                  restrictionTuple=restriction))
+    REST_response = client.delete(
+        f'/schema/{schema_name}/table/{table_name}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}'))
     assert REST_response.status_code == 200
     assert len(getattr(vm, table_name) & restriction) == 0
 
@@ -54,14 +60,15 @@ def test_delete_independent_without_cascade(token, client, connection, schemas_s
 def test_delete_invalid(token, client, connection, schemas_simple):
     schema_name = f'{SCHEMA_PREFIX}group1_simple'
     table_name = 'TableB'
-    restriction = dict()
+    restriction = dict(a_id=999)
+    filters = [dict(attributeName=k, operation='=', value=v)
+               for k, v in restriction.items()]
+    encoded_filters = b64encode(dumps(filters).encode('utf-8')).decode('utf-8')
+    q = dict(cascade='TRUE', restriction=encoded_filters)
     vm = dj.VirtualModule('group1_simple', schema_name)
-    REST_response = client.post(
-        '/delete_tuple?cascade=TRUE',
-        headers=dict(Authorization=f'Bearer {token}'),
-        json=dict(schemaName=schema_name,
-                  tableName=table_name,
-                  restrictionTuple=restriction))
+    REST_response = client.delete(
+        f'/schema/{schema_name}/table/{table_name}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}'))
     assert REST_response.status_code == 500
-    assert b'Restriction is invalid' in REST_response.data
+    assert b'Nothing to delete' in REST_response.data
     assert len(getattr(vm, table_name)()) == 3

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+from urllib.parse import urlencode
 from json import dumps
 from . import SCHEMA_PREFIX, client, token, group1_token, connection, schemas_simple
 
@@ -6,15 +7,17 @@ from . import SCHEMA_PREFIX, client, token, group1_token, connection, schemas_si
 def test_dependencies_admin(token, client, schemas_simple):
     schema_name = f'{SCHEMA_PREFIX}group1_simple'
     table_name = 'TableA'
-    restriction = b64encode(dumps(dict(a_id=0)).encode('utf-8')).decode('utf-8')
+    restriction = dict(a_id=0)
+    restriction = [dict(attributeName=k, operation='=', value=v)
+                   for k, v in restriction.items()]
+    restriction = b64encode(dumps(restriction).encode('utf-8')).decode('utf-8')
+    q = dict(restriction=restriction)
     REST_dependencies = client.get(
-        f"""/record/dependency?schemaName={
-            schema_name}&tableName={table_name}&restriction={restriction}""",
+        f'/schema/{schema_name}/table/{table_name}/dependency?{urlencode(q)}',
         headers=dict(Authorization=f'Bearer {token}')).json['dependencies']
-    REST_records = client.post('/fetch_tuples',
-                               headers=dict(Authorization=f'Bearer {token}'),
-                               json=dict(schemaName=schema_name,
-                                         tableName=table_name)).json['tuples']
+    REST_records = client.get(
+        f'/schema/{schema_name}/table/{table_name}/record',
+        headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 2
     assert len(REST_dependencies) == 4
     table_a = [el for el in REST_dependencies

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -14,10 +14,9 @@ def test_filters(token, client, Student):
     encoded_restriction = b64encode(dumps(restriction).encode('utf-8')).decode('utf-8')
     q = dict(limit=10, page=1, order='student_enroll_date DESC',
              restriction=encoded_restriction)
-    REST_records = client.post(f'/fetch_tuples?{urlencode(q)}',
-                               headers=dict(Authorization=f'Bearer {token}'),
-                               json=dict(schemaName=Student.database,
-                                         tableName='Student')).json['tuples']
+    REST_records = client.get(
+          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+          headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 10
     assert REST_records[0][3] == datetime(2021, 1, 16).timestamp()
     # 'equal' null
@@ -25,10 +24,9 @@ def test_filters(token, client, Student):
     encoded_restriction = b64encode(dumps(restriction).encode('utf-8')).decode('utf-8')
     q = dict(limit=10, page=2, order='student_id ASC',
              restriction=encoded_restriction)
-    REST_records = client.post(f'/fetch_tuples?{urlencode(q)}',
-                               headers=dict(Authorization=f'Bearer {token}'),
-                               json=dict(schemaName=Student.database,
-                                         tableName='Student')).json['tuples']
+    REST_records = client.get(
+          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+          headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 10
     assert all([r[5] is None for r in REST_records])
     assert REST_records[0][0] == 34
@@ -37,10 +35,9 @@ def test_filters(token, client, Student):
     encoded_restriction = b64encode(dumps(restriction).encode('utf-8')).decode('utf-8')
     q = dict(limit=10, page=1, order='student_id ASC',
              restriction=encoded_restriction)
-    REST_records = client.post(f'/fetch_tuples?{urlencode(q)}',
-                               headers=dict(Authorization=f'Bearer {token}'),
-                               json=dict(schemaName=Student.database,
-                                         tableName='Student')).json['tuples']
+    REST_records = client.get(
+          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+          headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 10
     assert all([r[0] != 2 for r in REST_records])
     assert REST_records[-1][0] == 10
@@ -50,10 +47,9 @@ def test_filters(token, client, Student):
     encoded_restriction = b64encode(dumps(restriction).encode('utf-8')).decode('utf-8')
     q = dict(limit=10, page=1, order='student_id ASC',
              restriction=encoded_restriction)
-    REST_records = client.post(f'/fetch_tuples?{urlencode(q)}',
-                               headers=dict(Authorization=f'Bearer {token}'),
-                               json=dict(schemaName=Student.database,
-                                         tableName='Student')).json['tuples']
+    REST_records = client.get(
+          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+          headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 1
     assert REST_records[0][1] == 'Norma Fisher'
     assert REST_records[0][6] == 0

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -3,4 +3,4 @@ from . import client
 
 
 def test_version(client):
-    assert client.get('/version').data.decode() == version
+    assert client.get('/version').json['version'] == version

--- a/tests/test_list_tables.py
+++ b/tests/test_list_tables.py
@@ -2,24 +2,23 @@ from . import client, connection, token, schema_main, ParentPart
 from flask.wrappers import Response
 import datajoint as dj
 
+
 def test_list_tables(token, client, ParentPart):
     ScanData, ProcessScanData = ParentPart
-    REST_tables = client.post(
-        '/list_tables',
-        headers=dict(Authorization=f'Bearer {token}'),
-        json=dict(schemaName=ScanData.database)).json['tableTypeAndNames']
-    assert ScanData.__name__ == REST_tables['manual_tables'][0]
-    assert ProcessScanData.__name__ == REST_tables['computed_tables'][0]
+    REST_tables = client.get(
+        f'/schema/{ScanData.database}/table',
+        headers=dict(Authorization=f'Bearer {token}')).json['tableTypes']
+    assert ScanData.__name__ == REST_tables['manual'][0]
+    assert ProcessScanData.__name__ == REST_tables['computed'][0]
     assert f"""{ProcessScanData.__name__}.{
-        ProcessScanData.ProcessScanDataPart.__name__}""" == REST_tables['part_tables'][0]
+        ProcessScanData.ProcessScanDataPart.__name__}""" == REST_tables['part'][0]
+
 
 def test_invalid_schema_list_table(token, client, schema_main):
     # Test invalid schema
-    response: Response = client.post(
-        '/list_tables', 
-        headers=dict(Authorization=f'Bearer {token}'),
-        json=dict(schemaName='invalid_schema')
-        )
+    response: Response = client.get(
+        f'/schema/{"invalid_schema"}/table',
+        headers=dict(Authorization=f'Bearer {token}'))
 
     assert(response.status_code != 200)
     assert('invalid_schema' not in dj.list_schemas())

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,7 +4,7 @@ import datajoint as dj
 
 
 def test_schemas(token, client, connection, schemas_simple):
-    REST_schemas = client.get('/list_schemas',
+    REST_schemas = client.get('/schema',
                               headers=dict(
                                   Authorization=f'Bearer {token}')).json['schemaNames']
     assert set(REST_schemas) == set(

--- a/tests/test_table_metadata.py
+++ b/tests/test_table_metadata.py
@@ -3,14 +3,12 @@ from . import SCHEMA_PREFIX, client, token, connection, schemas_simple
 
 def test_definition(token, client, schemas_simple):
     simple1, simple2 = schemas_simple
-    REST_definition = client.post('/get_table_definition',
-                                  headers=dict(Authorization=f'Bearer {token}'),
-                                  json=dict(schemaName=simple1.database,
-                                            tableName='TableB')).data
+    REST_definition = client.get(
+        f'/schema/{simple1.database}/table/{"TableB"}/definition',
+        headers=dict(Authorization=f'Bearer {token}')).data
     assert f'{simple1.database}.TableA' in REST_definition.decode('utf-8')
 
-    REST_definition = client.post('/get_table_definition',
-                                  headers=dict(Authorization=f'Bearer {token}'),
-                                  json=dict(schemaName=simple2.database,
-                                            tableName='DiffTableB')).data
+    REST_definition = client.get(
+        f'/schema/{simple2.database}/table/{"DiffTableB"}/definition',
+        headers=dict(Authorization=f'Bearer {token}')).data
     assert f'`{simple1.database}`.`#table_a`' in REST_definition.decode('utf-8')


### PR DESCRIPTION
### Added
- Local database instance pre-populated with sample data for `dev` Docker Compose environment. PR #99
- Capability to insert multiple, update multiple, and delete multiple. PR #99
- Allow dependency restriction to include secondary attributes from parent table. PR #99

### Changed
- Rename service `pharus` to `pharus-docs` in `docs` Docker Compose environment to allow simulataneous development. PR #99
- Update NGINX reverse proxy image reference. PR #99
- Refactored API design to align with common REST resource naming convention. (#38) PR #99
- Hide classes and methods that are internal and subject to change. PR #99

### Removed
- `InvalidDeleteRequest` exception is no longer available as it is now allowed to delete more than 1 record at a time. PR #99

Fix #38