### PR TITLE
Fix issue with uuid restricitons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 ### Removed
 - `InvalidDeleteRequest` exception is no longer available as it is now allowed to delete more than 1 record at a time. PR #99
 
+### Fixed
+- `uuid` types not properly restricted on `GET /record`, `DELETE /record`, and `GET /dependency`. PR #102
+
 ## [0.1.0b2] - 2021-03-12
 
 ### Fixed

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 import pytest
 from pharus.server import app
+from uuid import UUID
 from os import getenv
 import datajoint as dj
 from datetime import date
@@ -134,6 +135,22 @@ def Student(schema_main):
                      bool(getrandbits(1))) for i in range(100)]
     yield Student
     Student.drop()
+
+
+@pytest.fixture
+def Computer(schema_main):
+    """Computer table for testing."""
+    @schema_main
+    class Computer(dj.Lookup):
+        definition = """
+        computer_id: uuid
+        ---
+        computer_brand: enum('HP', 'DELL')
+        """
+        contents = [(UUID('ffffffff-86d5-4af7-a013-89bde75528bd'), 'HP'),
+                    (UUID('aaaaaaaa-86d5-4af7-a013-89bde75528bd'), 'DELL')]
+    yield Computer
+    Computer.drop()
 
 
 @pytest.fixture

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -2,7 +2,7 @@ from json import dumps
 from base64 import b64encode
 from urllib.parse import urlencode
 from datetime import date, datetime
-from . import token, client, connection, schema_main, Student
+from . import token, client, connection, schema_main, Student, Computer
 
 
 def test_filters(token, client, Student):
@@ -15,8 +15,8 @@ def test_filters(token, client, Student):
     q = dict(limit=10, page=1, order='student_enroll_date DESC',
              restriction=encoded_restriction)
     REST_records = client.get(
-          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
-          headers=dict(Authorization=f'Bearer {token}')).json['records']
+        f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 10
     assert REST_records[0][3] == datetime(2021, 1, 16).timestamp()
     # 'equal' null
@@ -25,8 +25,8 @@ def test_filters(token, client, Student):
     q = dict(limit=10, page=2, order='student_id ASC',
              restriction=encoded_restriction)
     REST_records = client.get(
-          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
-          headers=dict(Authorization=f'Bearer {token}')).json['records']
+        f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 10
     assert all([r[5] is None for r in REST_records])
     assert REST_records[0][0] == 34
@@ -36,8 +36,8 @@ def test_filters(token, client, Student):
     q = dict(limit=10, page=1, order='student_id ASC',
              restriction=encoded_restriction)
     REST_records = client.get(
-          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
-          headers=dict(Authorization=f'Bearer {token}')).json['records']
+        f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 10
     assert all([r[0] != 2 for r in REST_records])
     assert REST_records[-1][0] == 10
@@ -48,8 +48,22 @@ def test_filters(token, client, Student):
     q = dict(limit=10, page=1, order='student_id ASC',
              restriction=encoded_restriction)
     REST_records = client.get(
-          f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
-          headers=dict(Authorization=f'Bearer {token}')).json['records']
+        f'/schema/{Student.database}/table/{"Student"}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}')).json['records']
     assert len(REST_records) == 1
     assert REST_records[0][1] == 'Norma Fisher'
     assert REST_records[0][6] == 0
+
+
+def test_uuid_filter(token, client, Computer):
+    """Verify UUID can be properly restricted."""
+    restriction = [dict(attributeName='computer_id', operation='=',
+                        value='aaaaaaaa-86d5-4af7-a013-89bde75528bd')]
+    encoded_restriction = b64encode(dumps(restriction).encode('utf-8')).decode('utf-8')
+    q = dict(limit=10, page=1, order='computer_id DESC',
+             restriction=encoded_restriction)
+    REST_records = client.get(
+        f'/schema/{Computer.database}/table/{"Computer"}/record?{urlencode(q)}',
+        headers=dict(Authorization=f'Bearer {token}')).json['records']
+    assert len(REST_records) == 1
+    assert REST_records[0][1] == 'DELL'


### PR DESCRIPTION
### Fixed
- `uuid` types not properly restricted on `GET /record`, `DELETE /record`, and `GET /dependency`. PR #102