### PR TITLE
fix filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.8.2] - 2023-03-23
+
+### Added
+- Forms now allow you to specify presets using their schemas and tables to avoid collisions [#158](https://github.com/datajoint/pharus/pull/158)
+
 ## [0.8.1] - 2023-03-20
 
 ### Added
@@ -275,6 +280,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Support for DataJoint attribute types: `varchar`, `int`, `float`, `datetime`, `date`, `time`, `decimal`, `uuid`.
 - Check dependency utility to determine child table references.
 
+[0.8.2]: https://github.com/datajoint/pharus/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/datajoint/pharus/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/datajoint/pharus/compare/0.7.3...0.8.0
 [0.7.3]: https://github.com/datajoint/pharus/compare/0.7.2...0.7.3

--- a/pharus/component_interface.py
+++ b/pharus/component_interface.py
@@ -353,10 +353,25 @@ class InsertComponent(Component):
 
         # Helper function to filter out fields not in the insert,
         # as well as apply the fields_map
-        def filterPreset(preset: dict):
-            return {
-                (self.input_lookup[k] if k in self.input_lookup else k): v
+        def filter_preset(preset: dict):
+            # Any key that follows the schema.table.attribute format,
+            # and its schema.table is not in the forms is filtered out.
+
+            preset_with_tables_filtered = {
+                k: v
                 for k, v in preset.items()
+                if (
+                    len(k.split(".")) == 1
+                    or ".".join(k.split(".")[0:2]) in self.component_config["tables"]
+                )
+            }
+            return {
+                (
+                    self.input_lookup[k.split(".").pop()]
+                    if k.split(".").pop() in self.input_lookup
+                    else k.split(".").pop()
+                ): v
+                for k, v in preset_with_tables_filtered.items()
             }
 
         if "presets" not in self.component_config:
@@ -367,7 +382,7 @@ class InsertComponent(Component):
             )
 
         filtered_preset_dictionary = {
-            k: filterPreset(v) for k, v in self.presets_dict.items()
+            k: filter_preset(v) for k, v in self.presets_dict.items()
         }
 
         return (

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/tests/init/test_dynamic_api_spec.yaml
+++ b/tests/init/test_dynamic_api_spec.yaml
@@ -96,7 +96,7 @@ SciViz: # top level tab
                   destination: c_name
               presets: >
                 def presets():
-                    return {'preset 1': {'b_id': 14}}
+                    return {'preset 1': {'b_id': 14, 'someschema.sometable.attributetobefiltered' : 'blabla'}}
             insert3:
               route: /insert3
               x: 1


### PR DESCRIPTION
Pr is  for adding the ability to prefix preset attributes to avoid collisions.

example:
`someschema.Table1.notes`
`someschema.Table2.notes`

both tables have a notes attribute but you can use the same preset dictionary for both tables because attribute presets defined this way get filtered if their `schema.table` is not in the form.