### PR TITLE
feat: :sparkles: allow nullable fk as secondary attr in forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.8.11] - TBD
+
+### Fixed
+
+- bug with forms that was preventing nullable foreign keys from being null in sci-viz[#172](https://github.com/datajoint/pharus/pull/172)
+
 ## [0.8.10] - 2023-11-16
 
 ### Fixed
@@ -334,6 +340,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Support for DataJoint attribute types: `varchar`, `int`, `float`, `datetime`, `date`, `time`, `decimal`, `uuid`.
 - Check dependency utility to determine child table references.
 
+[0.8.11]: https://github.com/datajoint/pharus/compare/0.8.9...0.8.11
 [0.8.10]: https://github.com/datajoint/pharus/compare/0.8.9...0.8.10
 [0.8.9]: https://github.com/datajoint/pharus/compare/0.8.8...0.8.9
 [0.8.8]: https://github.com/datajoint/pharus/compare/0.8.7...0.8.8

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -45,7 +45,6 @@ services:
           flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py --ignore=W503,W605
           black /main/tests --check -v
           flake8 /main/tests --count --max-complexity=20 --max-line-length=94 --statistics --ignore=F401,F811,W503
-          tail -f /dev/null
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -35,7 +35,7 @@ services:
         set -e
         if echo "${AS_SCRIPT}" | grep -i true &>/dev/null; then
           echo "------ SYNTAX TESTS ------"
-          PKG_DIR=/opt/conda/lib/python${PY_VER}/site-packages/pharus
+          PKG_DIR=/main/pharus
           flake8 $${PKG_DIR} --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 /main/tests --count --select=E9,F63,F7,F82 --show-source --statistics
           echo "------ UNIT TESTS ------"
@@ -45,6 +45,7 @@ services:
           flake8 $${PKG_DIR} --count --max-complexity=20 --max-line-length=94 --statistics --exclude=*dynamic_api.py --ignore=W503,W605
           black /main/tests --check -v
           flake8 /main/tests --count --max-complexity=20 --max-line-length=94 --statistics --ignore=F401,F811,W503
+          tail -f /dev/null
         else
           echo "=== Running ==="
           echo "Please see 'docker-compose-test.yaml' for detail on running tests."

--- a/pharus/component_interface.py
+++ b/pharus/component_interface.py
@@ -265,6 +265,10 @@ class InsertComponent(Component):
         self.datatype_lookup = {
             k: v[1] for t in self.tables for k, v in t.heading.attributes.items()
         }
+        self.nullable_lookup = [
+            k for t in self.tables for k, v in t.heading.attributes.items() if v.nullable
+        ]
+        print(self.nullable_lookup, flush=True)
 
         if "presets" in self.component_config:
             lcls = locals()
@@ -305,7 +309,7 @@ class InsertComponent(Component):
         source_fields = {
             **{
                 (p_name := f"{p.database}.{dj.utils.to_camel_case(p.table_name)}"): {
-                    "values": [NumpyEncoder.dumps(row) for row in p.fetch("KEY")],
+                    "values": [NumpyEncoder.dumps(row) for row in p.fetch("KEY")] if not all(k in self.nullable_lookup for k in p.primary_key) else [NumpyEncoder.dumps(row) for row in p.fetch("KEY")] + [NumpyEncoder.dumps({k: None for k in p.primary_key})],
                     "type": "table",
                     "name": p_name,
                 }

--- a/pharus/component_interface.py
+++ b/pharus/component_interface.py
@@ -266,7 +266,10 @@ class InsertComponent(Component):
             k: v[1] for t in self.tables for k, v in t.heading.attributes.items()
         }
         self.nullable_lookup = [
-            k for t in self.tables for k, v in t.heading.attributes.items() if v.nullable
+            k
+            for t in self.tables
+            for k, v in t.heading.attributes.items()
+            if v.nullable
         ]
         print(self.nullable_lookup, flush=True)
 
@@ -309,7 +312,10 @@ class InsertComponent(Component):
         source_fields = {
             **{
                 (p_name := f"{p.database}.{dj.utils.to_camel_case(p.table_name)}"): {
-                    "values": [NumpyEncoder.dumps(row) for row in p.fetch("KEY")] if not all(k in self.nullable_lookup for k in p.primary_key) else [NumpyEncoder.dumps(row) for row in p.fetch("KEY")] + [NumpyEncoder.dumps({k: None for k in p.primary_key})],
+                    "values": [NumpyEncoder.dumps(row) for row in p.fetch("KEY")]
+                    if not all(k in self.nullable_lookup for k in p.primary_key)
+                    else [NumpyEncoder.dumps(row) for row in p.fetch("KEY")]
+                    + [NumpyEncoder.dumps({k: None for k in p.primary_key})],
                     "type": "table",
                     "name": p_name,
                 }

--- a/pharus/dynamic_api_gen.py
+++ b/pharus/dynamic_api_gen.py
@@ -160,9 +160,11 @@ def {method_name}() -> dict:
                                 component_name=comp_name,
                                 component=json.dumps(comp),
                                 static_config=static_config,
-                                payload="payload=request.get_json()"
-                                if comp["type"].split(":", 1)[0] == "form"
-                                else "",
+                                payload=(
+                                    "payload=request.get_json()"
+                                    if comp["type"].split(":", 1)[0] == "form"
+                                    else ""
+                                ),
                                 method_name_type="dj_query_route",
                             )
                         )

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -1,4 +1,5 @@
 """Library for interfaces into DataJoint pipelines."""
+
 import datajoint as dj
 from datajoint import DataJointError
 from datajoint.utils import to_camel_case
@@ -245,12 +246,14 @@ class _DJConnector:
                         attribute_info.nullable,
                         attribute_info.default,
                         attribute_info.autoincrement,
-                        [
-                            dict({"text": str(v), "value": v})
-                            for (v,) in (dj.U(attribute_name) & query).fetch()
-                        ]
-                        if include_unique_values
-                        else None,
+                        (
+                            [
+                                dict({"text": str(v), "value": v})
+                                for (v,) in (dj.U(attribute_name) & query).fetch()
+                            ]
+                            if include_unique_values
+                            else None
+                        ),
                     )
                 )
             else:
@@ -261,12 +264,14 @@ class _DJConnector:
                         attribute_info.nullable,
                         attribute_info.default,
                         attribute_info.autoincrement,
-                        [
-                            dict({"text": str(v), "value": v})
-                            for (v,) in (dj.U(attribute_name) & query).fetch()
-                        ]
-                        if include_unique_values
-                        else None,
+                        (
+                            [
+                                dict({"text": str(v), "value": v})
+                                for (v,) in (dj.U(attribute_name) & query).fetch()
+                            ]
+                            if include_unique_values
+                            else None
+                        ),
                     )
                 )
 

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -1,4 +1,5 @@
 """Exposed REST API."""
+
 from os import environ
 from pathlib import Path
 from envyaml import EnvYAML

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -128,7 +128,7 @@ def api_version() -> str:
     Content-Type: application/json
 
     {
-        "version": "0.8.10"
+        "version": "0.8.11"
     }
     ```
 

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.8.10"
+__version__ = "0.8.11"

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,2 +1,3 @@
 """Package metadata."""
+
 __version__ = "0.8.10"


### PR DESCRIPTION
This solves an issue for forms when you have a nullable foreign key reference as a secondary attribute. The solution checks whether a foreign key was defined as nullable and then updates the form payload with an additional null row. This would allow users in the front end to insert null instead of picking keys that already exist in the table the foreign key came from.

Since this is done entirely in the backend, no changes are needed in the frontend. Users will now just see an option in the frontend dropdown that will insert null for them.