### PR TITLE
PLAT-270: server.protected_route can optionally inject user object

### DIFF
--- a/pharus/dynamic_api_gen.py
+++ b/pharus/dynamic_api_gen.py
@@ -28,7 +28,7 @@ except (ModuleNotFoundError, ImportError):
     route_template = """
 
 @app.route('{route}', methods={rest_verb})
-@protected_route(include_user_obj=False)
+@protected_route
 def {method_name}(connection: dj.Connection) -> dict:
 
     if request.method in {rest_verb}:

--- a/pharus/dynamic_api_gen.py
+++ b/pharus/dynamic_api_gen.py
@@ -28,7 +28,7 @@ except (ModuleNotFoundError, ImportError):
     route_template = """
 
 @app.route('{route}', methods={rest_verb})
-@protected_route
+@protected_route(include_user_obj=False)
 def {method_name}(connection: dj.Connection) -> dict:
 
     if request.method in {rest_verb}:

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -331,7 +331,7 @@ def login() -> dict:
 
 
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema", methods=["GET"])
-@protected_route
+@protected_route(include_user_obj=False)
 def schema(connection: dj.Connection) -> dict:
     """
     Handler for ``/schema`` route.
@@ -403,7 +403,7 @@ def schema(connection: dj.Connection) -> dict:
 @app.route(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table", methods=["GET"]
 )
-@protected_route
+@protected_route(include_user_obj=False)
 def table(
     connection: dj.Connection,
     schema_name: str,
@@ -489,7 +489,7 @@ def table(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record",
     methods=["GET", "POST", "PATCH", "DELETE"],
 )
-@protected_route
+@protected_route(include_user_obj=False)
 def record(
     connection: dj.Connection,
     schema_name: str,
@@ -885,7 +885,7 @@ def record(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/definition",
     methods=["GET"],
 )
-@protected_route
+@protected_route(include_user_obj=False)
 def definition(
     connection: dj.Connection,
     schema_name: str,
@@ -975,7 +975,7 @@ def definition(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/attribute",
     methods=["GET"],
 )
-@protected_route
+@protected_route(include_user_obj=False)
 def attribute(
     connection: dj.Connection,
     schema_name: str,
@@ -1161,7 +1161,7 @@ def attribute(
     f"{environ.get('PHARUS_PREFIX', '')}/spec",
     methods=["GET"],
 )
-@protected_route
+@protected_route(include_user_obj=False)
 def spec(
     connection: dj.Connection,
 ) -> dict:
@@ -1187,7 +1187,7 @@ def spec(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/dependency",
     methods=["GET"],
 )
-@protected_route
+@protected_route(include_user_obj=False)
 def dependency(
     connection: dj.Connection,
     schema_name: str,

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -54,15 +54,46 @@ if (
     )
 
 
-def protected_route(function: Callable) -> Callable:
+def doublewrap(f):
+    '''
+    A decorator decorator, allowing the decorator to be used as:
+    @decorator(with, arguments, and=kwargs)
+    or
+    @decorator
+
+    Adapted from https://stackoverflow.com/a/14412901
+    '''
+    @wraps(f)
+    def new_dec(*args, **kwargs):
+        if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+            # actual decorated function
+            return f(args[0])
+        else:
+            # decorator arguments
+            return lambda realf: f(realf, *args, **kwargs)
+
+    return new_dec
+
+
+@doublewrap
+def protected_route(function: Callable, include_user_obj: bool = False) -> Callable:
     """
     Protected route function decorator which authenticates requests.
+    This function should be decorated with doublewrap, allowing the decorator
+    to be used as:
+
+    @protected_route
+    or equivalently
+    @protected_route(include_user_obj=False)
+
+    If include_user_obj is set to True, then the wrapped function should
+    accept a kwarg user_obj which will contain the decoded JWT token.
 
     Args:
         function: Function to decorate, typically routes
 
     Returns:
-        Function's output if JWT authetication is successful, otherwise return error message
+        Wrapped function
     """
 
     @wraps(function)
@@ -93,6 +124,8 @@ def protected_route(function: Callable) -> Callable:
                 user=connect_creds["username"],
                 password=connect_creds["password"],
             )
+            if include_user_obj:
+                kwargs.update(user_obj=connect_creds)
             return function(connection, **kwargs)
         except Exception as e:
             return str(e), 401

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -114,7 +114,7 @@ def protected_route(function: Callable, include_user_obj: bool = False) -> Calla
                     "databaseAddress": request.args["database_host"],
                     "username": decoded_jwt[environ.get("PHARUS_OIDC_SUBJECT_KEY")],
                     "password": encoded_jwt,
-                    "groups": decoded_jwt.get("groups", [])
+                    "groups": decoded_jwt.get("groups", []),
                 }
             else:
                 connect_creds = jwt.decode(

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -55,14 +55,15 @@ if (
 
 
 def doublewrap(f):
-    '''
+    """
     A decorator decorator, allowing the decorator to be used as:
     @decorator(with, arguments, and=kwargs)
     or
     @decorator
 
     Adapted from https://stackoverflow.com/a/14412901
-    '''
+    """
+
     @wraps(f)
     def new_dec(*args, **kwargs):
         if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -331,7 +331,7 @@ def login() -> dict:
 
 
 @app.route(f"{environ.get('PHARUS_PREFIX', '')}/schema", methods=["GET"])
-@protected_route(include_user_obj=False)
+@protected_route
 def schema(connection: dj.Connection) -> dict:
     """
     Handler for ``/schema`` route.
@@ -403,7 +403,7 @@ def schema(connection: dj.Connection) -> dict:
 @app.route(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table", methods=["GET"]
 )
-@protected_route(include_user_obj=False)
+@protected_route
 def table(
     connection: dj.Connection,
     schema_name: str,
@@ -489,7 +489,7 @@ def table(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/record",
     methods=["GET", "POST", "PATCH", "DELETE"],
 )
-@protected_route(include_user_obj=False)
+@protected_route
 def record(
     connection: dj.Connection,
     schema_name: str,
@@ -885,7 +885,7 @@ def record(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/definition",
     methods=["GET"],
 )
-@protected_route(include_user_obj=False)
+@protected_route
 def definition(
     connection: dj.Connection,
     schema_name: str,
@@ -975,7 +975,7 @@ def definition(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/attribute",
     methods=["GET"],
 )
-@protected_route(include_user_obj=False)
+@protected_route
 def attribute(
     connection: dj.Connection,
     schema_name: str,
@@ -1161,7 +1161,7 @@ def attribute(
     f"{environ.get('PHARUS_PREFIX', '')}/spec",
     methods=["GET"],
 )
-@protected_route(include_user_obj=False)
+@protected_route
 def spec(
     connection: dj.Connection,
 ) -> dict:
@@ -1187,7 +1187,7 @@ def spec(
     f"{environ.get('PHARUS_PREFIX', '')}/schema/<schema_name>/table/<table_name>/dependency",
     methods=["GET"],
 )
-@protected_route(include_user_obj=False)
+@protected_route
 def dependency(
     connection: dj.Connection,
     schema_name: str,


### PR DESCRIPTION
From [PLAT-270](https://datajoint.atlassian.net/browse/PLAT-270):

> Plan to make pharus/pharus/server::protected_route both a decorator or a decorator factory (using this logic). When called as a decorator like @protected_route, the function behaves same as today. When called as a decorator factory like @protected_route(include_user_obj=True), the wrapper function also attempts to decode the JWT assuming it is a KeyCloak access token, and injects the resulting decoded dict as an argument user_obj after connection to the wrapped function.
