### PR TITLE
PLAT-343: cast to UTC epoch seconds explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.8.11] - TBD
+## [0.8.12] - 2024-10-03
 
 ### Fixed
 
-- bug with forms that was preventing nullable foreign keys from being null in sci-viz[#172](https://github.com/datajoint/pharus/pull/172)
+- Ensure that timestamps are in UTC format for the Works frontend [#179](https://github.com/datajoint/pharus/pull/179)
+
+## [0.8.11] - 2024-09-17
+
+### Fixed
+
+- Bug with forms that was preventing nullable foreign keys from being null in sci-viz[#172](https://github.com/datajoint/pharus/pull/172)
 - Bug in Works where NaN values were breaking the Works frontend [#174](https://github.com/datajoint/pharus/pull/174)
 
 ## [0.8.10] - 2023-11-16

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -1,5 +1,5 @@
-# PHARUS_VERSION=0.8.0 docker-compose -f docker-compose-deploy.yaml pull
-# PHARUS_VERSION=0.8.0 docker-compose -f docker-compose-deploy.yaml up -d
+# PHARUS_VERSION=0.8.12 docker-compose -f docker-compose-deploy.yaml pull
+# PHARUS_VERSION=0.8.12 docker-compose -f docker-compose-deploy.yaml up -d
 #
 # Intended for production deployment.
 # Note: You must run both commands above for minimal outage

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -201,9 +201,11 @@ class _DJConnector:
                         r"timestamp", attribute_info.type
                     ):
                         # Datetime or timestamp, use timestamp to covert to epoch time
-                        row.append(non_blobs_row[attribute_name].replace(
-                            tzinfo=datetime.timezone.utc
-                        ).timestamp())
+                        row.append(
+                            non_blobs_row[attribute_name]
+                            .replace(tzinfo=datetime.timezone.utc)
+                            .timestamp()
+                        )
                     elif attribute_info.type[0:7] == "decimal":
                         # Covert decimal to string
                         row.append(str(non_blobs_row[attribute_name]))

--- a/pharus/interface.py
+++ b/pharus/interface.py
@@ -201,7 +201,9 @@ class _DJConnector:
                         r"timestamp", attribute_info.type
                     ):
                         # Datetime or timestamp, use timestamp to covert to epoch time
-                        row.append(non_blobs_row[attribute_name].timestamp())
+                        row.append(non_blobs_row[attribute_name].replace(
+                            tzinfo=datetime.timezone.utc
+                        ).timestamp())
                     elif attribute_info.type[0:7] == "decimal":
                         # Covert decimal to string
                         row.append(str(non_blobs_row[attribute_name]))

--- a/pharus/server.py
+++ b/pharus/server.py
@@ -164,7 +164,7 @@ def api_version() -> str:
     Content-Type: application/json
 
     {
-        "version": "0.8.11"
+        "version": "0.8.12"
     }
     ```
 

--- a/pharus/version.py
+++ b/pharus/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.8.11"
+__version__ = "0.8.12"

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -17,7 +17,6 @@ def nei_nienborg_model_labeledvideo_file(
 
 
 class TestDJConnector:
-
     def test_can_init(self):
         djc = DJC()
         assert djc is not None


### PR DESCRIPTION
[PLAT-343](https://datajoint.atlassian.net/browse/PLAT-343) and [PLAT-358](https://datajoint.atlassian.net/browse/PLAT-358)

Implements https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp in case `.timestamp()` is called from a server that doesn't use UTC TZ.